### PR TITLE
Release 3.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -17,6 +19,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   npm-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup .npmrc file to publish to npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
-        node: [18.x, 20.x]
+        node: [20.x, 22.x, 24.x]
     name: Use Node.js ${{ matrix.node-version }}
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@
   </p>
 </div>
 
-<br/>
+<br>
 
 ---
 
-<br/>
+<br>
 
 # Wristband Client-Side Authentication SDK for React
 
@@ -30,33 +30,81 @@
 
 The SDK handles authentication interactions in your app’s React frontend. It’s designed to work in tandem with your backend server that integrates with Wristband using the Backend Server Integration Pattern. The backend exposes a required Session Endpoint that the React SDK calls to initialize the app in the browser with an authenticated user session. The backend can also optionally expose a Token Endpoint, allowing the React SDK to retrieve access tokens and store them in its client-side cache for direct use in browser-based requests.
 
+<br>
+
 ---
+
+<br>
+
+## Table of Contents
+
+- [Migrating From Older SDK Versions](#migrating-from-older-sdk-versions)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [1) Use the Wristband Auth Provider](#1-use-the-wristband-auth-provider)
+  - [2) Use Auth and Session Hooks](#2-use-auth-and-session-hooks)
+  - [3) Use Token Hook (Optional)](#3-use-token-hook-optional)
+  - [4) Use Auth Utility Functions](#4-use-auth-utility-functions)
+- [Transforming Session Metadata](#transforming-session-metadata)
+- [Executing Custom Logic After Session Initialization](#executing-custom-logic-after-session-initialization)
+- [API Reference](#api-reference)
+  - [WristbandAuthProvider](#wristbandauthprovidertsessionmetadata)
+  - [Hooks](#hooks)
+  - [Utility Functions](#utility-functions)
+- [Questions](#questions)
+
+<br>
+
+---
+
+<br>
 
 ## Migrating From Older SDK Versions
 
 On an older version of our SDK? Check out our migration guide:
 
-- [Instructions for migrating to Version 2.x (latest)](migration/v2/README.md)
+- [Instructions for migrating to Version 3.x (latest)](migration/v3/README.md)
+- [Instructions for migrating to Version 2.x](migration/v2/README.md)
 - [Instructions for migrating to Version 1.x](migration/v1/README.md)
+
+<br>
+
+## Prerequisites
+
+> **⚡ Try Our Quickstart Guides!**
+>
+> For the fastest way to get started with authentication, follow our [Quick Start Guide](https://docs.wristband.dev/docs/auth-quick-start). It walks you through setting up Wristband authentication for your backend server and React frontend in minutes. Refer back to this README for comprehensive documentation and advanced usage patterns.
+
+Before installing the SDK, ensure your environment meets the following requirements:
+
+- [Node.js](https://nodejs.org/en) >= 20.0.0
+- [React](https://react.dev/) >= 17.0.0
+- Your preferred package manager (npm >= 9.6.0, yarn, pnpm, etc.)
 
 <br>
 
 ## Installation
 
-```sh
+```bash
+# npm
 npm install @wristband/react-client-auth
-```
 
-or 
-
-```sh
+# Or yarn
 yarn add @wristband/react-client-auth
+
+# Or pnpm
+pnpm add @wristband/react-client-auth
 ```
+
+<br>
 
 ## Usage
 
-> [!NOTE]
-> Important: Before using this SDK, you must have already implemented the required backend server endpoints for authentication in your server: Login, Logout, and Session. This SDK connects to those existing endpoints but does not implement them for you. Optionally, if you plan to use access tokens directly from the browser, then your backend server will also need to implement the Token Endpoint.
+> [!WARNING]
+> **Important:** Before using this SDK, you must have already implemented the required [backend server endpoints](https://docs.wristband.dev/docs/backend-server-integration) for authentication in your server: Login, Callback, Logout, and Session. This SDK connects to those existing endpoints but does not implement them for you. Optionally, if you plan to use access tokens directly from the browser, then your backend server will also need to implement the Token Endpoint.
+
+<br>
 
 ### 1) Use the Wristband Auth Provider
 
@@ -117,7 +165,7 @@ This hook provides authentication status information and functionality:
 - `isAuthenticated`: Boolean indicating if the user has an authenticated session.
 - `isLoading`: Boolean indicating if the authentication status is still being determined.
 - `authError`: WristbandError object containing error details when authentication fails, or `null` when no error has occurred.
-- `authStatus`: Enum value for convenience (`LOADING`, `AUTHENTICATED`, or `UNAUTHENTICATED`).
+- `authStatus`: String literal value for convenience (`LOADING`, `AUTHENTICATED`, or `UNAUTHENTICATED`).
 - `clearAuthData()`: Function that destroys all auth, session, and token data (auth status becomes `UNAUTHENTICATED`).
 
 Use this hook when you need to control access to protected content by checking authentication status.  This enables common patterns like conditional rendering of authenticated/unauthenticated views, route protection, or dynamic UI updates based on the user's auth status.
@@ -181,7 +229,7 @@ This hook provides access to the authenticated user's session data:
 
 - `userId`: The authenticated user's ID.
 - `tenantId`: The ID of the tenant that the authenticated user belongs to.
-- `metadata`: Opional custom session metadata provided by your backend, if applicable (profile info, roles, etc.)
+- `metadata`: Optional custom session metadata provided by your backend, if applicable (profile info, roles, etc.)
 - `updateMetadata()`: Function to modify the metadata object stored in the client-side React Context. This enables real-time UI updates with new metadata values, but it is limited to the current browser session only. Any changes made with this function will not persist across page refreshes or be synchronized to your backend server.
 
 Use this hook when you need access to the user data provided by your backend's Session Endpoint. It helps you build personalized experiences based on the specific user information your server makes available.
@@ -262,7 +310,7 @@ Alternatively, the React SDK can extract the access token from the authenticated
 
 #### useWristbandToken()
 
-The useWristbandToken() hook exposes functionality for maanging client-side access tokens:
+The useWristbandToken() hook exposes functionality for managing access tokens in the browser:
 
 - `getToken()`: Retrieves a valid access token for making authenticated API calls to resource servers. Returns a cached token if available and not expired, otherwise fetches a fresh token from the configured `tokenUrl` endpoint. The access token does not persist across page navigations or refreshes. Your server's Token Endpoint is responsible for refreshing expired tokens by using the user's session state.
 - `clearToken()`: Function to modify the metadata object stored in the client-side React Context. This enables real-time UI updates with new metadata values, but it is limited to the current browser session only. Any changes made with this function will not persist across page refreshes or be synchronized to your backend server.
@@ -382,6 +430,8 @@ export function ExampleApiComponent() {
 }
 ```
 
+<br>
+
 ## Transforming Session Metadata
 
 The `transformSessionMetadata` prop on the `WristbandAuthProvider` provides a flexible way to reshape the raw session metadata returned from your backend server into a more convenient format for your frontend application.
@@ -480,6 +530,8 @@ function UserDashboard() {
 }
 ```
 
+<br>
+
 ## Executing Custom Logic After Session Initialization
 
 The `onSessionSuccess` property on `WristbandAuthProvider` allows you to execute custom initialization logic when a user's session is successfully retrieved from your server's Session Endpoint. The function is executed after session data is fetched but before the Provider's internal state is updated, making it the perfect place for initialization logic that depends on the user's identity. This is useful for post-authentication tasks including data prefetching, service configuration, global state initialization, and more.
@@ -512,7 +564,7 @@ function App() {
 }
 ```
 
-<br/>
+<br>
 
 ## API Reference
 
@@ -564,7 +616,7 @@ export default function App() {
 | sessionUrl | string | Yes | The URL of your server's Session Endpoint, which returns an authenticated user's userId, tenantId, and any optional metadata. |
 | transformSessionMetadata | `(rawSessionMetadata: unknown) => TSessionMetadata` | No | Function to transform raw metadata from the session response before storing it in context. Useful for converting data types, adding computed properties, filtering unnecessary properties, and ensuring type safety. |
 
-<br/>
+<br>
 
 ### Hooks
 
@@ -593,15 +645,15 @@ function AuthHook() {
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | authError | `WristbandError` or `null` | An error object details when session fetching or authentication fails. Provides error codes and messages for debugging. Only populated when `disableRedirectOnUnauthenticated` is true; otherwise, users are redirected to login on errors. If no error is encountered, then the value is `null`. |
-| authStatus | `AuthStatus` (enum) | Represents the current authentication status.<br><br> Possible values: `LOADING`, `AUTHENTICATED`, or `UNAUTHENTICATED`. |
+| authStatus | `AuthStatus` | Represents the current authentication status.<br><br> Possible values: `LOADING`, `AUTHENTICATED`, or `UNAUTHENTICATED`. |
 | clearAuthData | `() => void` | This function clears all client-side auth state including authentication status, user data, session metadata, cached tokens, and errors. |
 | isAuthenticated | boolean | A boolean indicator that is `true` when the user is authenticated and `false` otherwise. |
 | isLoading | boolean | A boolean indicator that is `true` when the authentication status is still being determined (e.g., during the initial session check) and `false` once the status is determined. |
 
 In the event an `authError` occurs, the `WristbandError` can have any of the following error codes:
 
-| Wristband Error Code | Description |
-| -------------------- | ----------- |
+| WristbandErrorCode | Description |
+| ------------------ | ----------- |
 | `INVALID_LOGIN_URL` | An invalid login URL value was provided to the SDK. |
 | `INVALID_LOGOUT_URL` | An invalid logout URL value was provided to the SDK (primarily for `redirectToLogout()`). |
 | `INVALID_SESSION_RESPONSE` | The session endpoint response is missing required fields. |
@@ -610,9 +662,9 @@ In the event an `authError` occurs, the `WristbandError` can have any of the fol
 | `INVALID_TOKEN_URL` | An invalid token URL value was provided to the SDK (only occurs if using `getToken()`). |
 | `SESSION_FETCH_FAILED` | The session endpoint returned an error other than 401. |
 | `TOKEN_FETCH_FAILED` | The token endpoint returned an error other than 401. |
-| `UNAUTHENTICATED` | The user is not authenticated and cannot request a session or token (typicaly from a 401 error). |
+| `UNAUTHENTICATED` | The user is not authenticated and cannot request a session or token (typically from a 401 error). |
 
-<br/>
+<br>
 
 #### `useWristbandSession<TSessionMetadata>()`
 
@@ -648,7 +700,7 @@ function SessionHook() {
 | updateMetadata | `(newMetadata: Partial<TSessionMetadata>) => void` | A function that lets you update the metadata object with type-safe partial updates. The type parameter you provide to the hook ensures that any updates you make are compatible with your defined metadata structure. This only updates the client-side state and does not persist changes to the server. |
 | userId | string | The unique identifier for the authenticated user. |
 
-<br/>
+<br>
 
 #### `useWristbandToken()`
 
@@ -676,11 +728,19 @@ function TokenHook() {
 | clearToken | `() => void` | Clears the cached access token and forces the next getToken() call to fetch a fresh token, assuming that the user still has a valid session cookie. |
 | getToken | `() => void` | Retrieves a valid access token for making authenticated API calls to resource servers. Returns a cached token if available and not expired; otherwise fetches a fresh token from the configured "tokenUrl" endpoint. Your server's Token Endpoint should automatically handle token expiration and refresh using the user's session cookie. |
 
-<br/>
+<br>
 
 ### Utility Functions
 
-#### `redirectToLogin(loginUrl: string, config?: LoginRedirectConfig): void`
+The SDK provides utility functions for handling login and logout redirects as well as CSRF token extraction for use with HTTP clients like Fetch.
+
+#### redirectToLogin()
+
+```typescript
+function redirectToLogin(loginUrl: string, config?: LoginRedirectConfig): void
+```
+
+The `redirectToLogin()` function initiates a redirect to your specified Login Endpoint URL and appends relevant query parameters based on the provided configuration (browser only).
 
 ```typescript
 import { redirectToLogin } from '@wristband/react-client-auth';
@@ -689,7 +749,7 @@ function handleLogin() {
   redirectToLogin('https://your-server.com/api/auth/login', {
     loginHint: 'user@company.com',
     returnUrl: window.location.href,
-    tenantDomain: 'acme-corp',
+    tenantName: 'acme-corp',
     tenantCustomDomain: 'auth.acme.com'
   });
 }
@@ -700,18 +760,24 @@ function handleLogin() {
 | loginHint | string | No | Pre-fills the Tenant Login Page form with a specific username or email. Sent as the `login_hint` query parameter to your Login Endpoint. |
 | returnUrl | string | No | URL to redirect back to after successful authentication. Sent as the `return_url` query parameter to your Login Endpoint. |
 | tenantCustomDomain | string | No | Tenant custom domain for routing to the correct Tenant Login Page. Sent as the `tenant_custom_domain` query parameter to your Login Endpoint. |
-| tenantDomain | string | No | Tenant domain name for routing to the correct Tenant Login Page. Sent as the `tenant_domain` query parameter to your Login Endpoint. |
+| tenantName | string | No | Tenant name for routing to the correct Tenant Login Page. Sent as the `tenant_name` query parameter to your Login Endpoint. |
 
-<br/>
+<br>
 
-#### `redirectToLogout(logoutUrl: string, config?: LogoutRedirectConfig): void`
+#### redirectToLogout()
+
+```typescript
+function redirectToLogout(logoutUrl: string, config?: LogoutRedirectConfig): void
+```
+
+The `redirectToLogout()` function navigates the user to your specified Logout Endpoint URL and can append additional parameters as needed (browser only).
 
 ```typescript
 import { redirectToLogout } from '@wristband/react-client-auth';
 
 function handleLogout() {
   redirectToLogout('https://your-server.com/api/auth/logout', {
-    tenantDomain: 'acme-corp',
+    tenantName: 'acme-corp',
     tenantCustomDomain: 'auth.acme.com'
   });
 }
@@ -720,12 +786,64 @@ function handleLogout() {
 | Logout Redirect Config | Type | Required? | Description |
 | ---------------------- | ---- | --------- | ----------- |
 | tenantCustomDomain | string | No | Tenant custom domain for routing to the correct Tenant Login Page after logout. Sent as the `tenant_custom_domain` query parameter to your Logout Endpoint. |
-| tenantDomain | string | No | Tenant domain name for routing to the correct Tenant Login Page after logout. Sent as the `tenant_domain` query parameter to your Logout Endpoint. |
+| tenantName | string | No | Tenant domain name for routing to the correct Tenant Login Page after logout. Sent as the `tenant_name` query parameter to your Logout Endpoint. |
 
-<br/>
+<br>
+
+#### getCsrfToken()
+
+```typescript
+function getCsrfToken(cookieName?: string): string | undefined
+```
+
+The `getCsrfToken()` utility function extracts the CSRF token from a browser cookie. This is particularly useful when using the Fetch API or other HTTP clients that don't automatically handle CSRF tokens like Axios does.
+
+Use this function to retrieve the CSRF token and include it in your request headers for CSRF protection.
+```typescript
+import { getCsrfToken } from '@wristband/react-client-auth';
+
+async function makeApiCall() {
+  const csrfToken = getCsrfToken();
+  
+  const response = await fetch('/api/endpoint', {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-TOKEN': csrfToken ?? ''
+    },
+    body: JSON.stringify({ data: 'example' })
+  });
+  
+  if (!response.ok) {
+    if ([401, 403].includes(response.status)) {
+      window.location.href = '/api/auth/login';
+      return;
+    }
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  
+  return await response.json();
+}
+```
+
+**Parameters:**
+- `cookieName` (optional): The name of the CSRF cookie. Defaults to `'CSRF-TOKEN'`.
+
+**Returns:**
+- `string | undefined`: The CSRF token value, or `undefined` if the cookie is not found or if running server-side.
+
+**Custom Cookie Name Example:**
+
+If your backend uses a different cookie name for CSRF tokens, you can specify it:
+```typescript
+const csrfToken = getCsrfToken('X-XSRF-TOKEN');
+```
+
+<br>
 
 ## Questions
 
 Reach out to the Wristband team at <support@wristband.dev> for any questions regarding this SDK.
 
-<br/>
+<br>

--- a/migration/v3/README.md
+++ b/migration/v3/README.md
@@ -1,0 +1,244 @@
+<div align="center">
+  <a href="https://wristband.dev">
+    <picture>
+      <img src="https://assets.wristband.dev/images/email_branding_logo_v1.png" alt="Github" width="297" height="64">
+    </picture>
+  </a>
+  <p align="center">
+    Migration instruction from version v2.x to version v3.x
+  </p>
+  <p align="center">
+    <b>
+      <a href="https://wristband.dev">Website</a> • 
+      <a href="https://docs.wristband.dev/">Documentation</a>
+    </b>
+  </p>
+</div>
+
+<br/>
+
+---
+
+<br/>
+
+# Migration instruction from version v2.x to version v3.x
+
+## Table of Contents
+
+- [Tenant Domain Property Rename](#tenant-domain-property-rename)
+- [Type Changes: Enums to String Literal Unions](#type-changes-enums-to-string-literal-unions)
+
+<br>
+
+## Tenant Domain Property Rename
+
+The `tenantDomain` configuration property has been renamed to `tenantName` in the `redirectToLogin()` and `redirectToLogout()` utility functions as part of a broader standardization across the Wristband platform. This change improves clarity by better reflecting what the value actually represents—a tenant's unique name identifier (e.g., `acme-corp`), not a full domain (e.g., `acme.com`).
+
+Additionally, the query parameter sent to your backend server's Login and Logout Endpoints has changed from `tenant_domain` to `tenant_name`.
+
+> **⚠️ Important:**
+>
+> Before upgrading to v3.x and using these utility functions, ensure your backend SDK supports the `tenantName` property in your Login and Logout Endpoint configurations. If your backend SDK does not yet support this naming convention, you have two options:
+> 
+> 1. **Upgrade your backend SDK first** to support the new `tenantName` convention (if possible)
+> 2. **Use a backwards-compatible approach** by passing `tenant_domain` as a query parameter directly in the URL until your backend is upgraded
+
+**Before (v2.x):**
+```typescript
+import { redirectToLogin, redirectToLogout } from '@wristband/react-client-auth';
+
+// Login with tenant domain
+function handleLogin() {
+  redirectToLogin('https://your-server.com/api/auth/login', {
+    loginHint: 'user@company.com',
+    returnUrl: window.location.href,
+    tenantDomain: 'acme-corp',  // Old property name
+    tenantCustomDomain: 'auth.acme.com'
+  });
+}
+
+// Logout with tenant domain
+function handleLogout() {
+  redirectToLogout('https://your-server.com/api/auth/logout', {
+    tenantDomain: 'acme-corp',  // Old property name
+    tenantCustomDomain: 'auth.acme.com'
+  });
+}
+```
+
+**After (v3.x):**
+```typescript
+import { redirectToLogin, redirectToLogout } from '@wristband/react-client-auth';
+
+// Login with tenant name
+function handleLogin() {
+  redirectToLogin('https://your-server.com/api/auth/login', {
+    loginHint: 'user@company.com',
+    returnUrl: window.location.href,
+    tenantName: 'acme-corp',  // New property name
+    tenantCustomDomain: 'auth.acme.com'
+  });
+}
+
+// Logout with tenant name
+function handleLogout() {
+  redirectToLogout('https://your-server.com/api/auth/logout', {
+    tenantName: 'acme-corp',  // New property name
+    tenantCustomDomain: 'auth.acme.com'
+  });
+}
+```
+
+### Backend Query Parameter Changes
+
+If your backend server's Login and Logout Endpoints read the `tenant_domain` query parameter, you'll need to update them to read `tenant_name` instead.
+
+**Before (v2.x):**
+```typescript
+// Backend Login Endpoint
+const tenantDomain = request.query.tenant_domain;  // Old query param
+```
+
+**After (v3.x):**
+```typescript
+// Backend Login Endpoint
+const tenantName = request.query.tenant_name;  // New query param
+```
+
+**Backwards Compatible Approach (if backend doesn't support `tenantName` yet):**
+
+If your backend SDK doesn't yet support `tenantName`, you can pass `tenant_domain` directly in the URL as a query parameter:
+
+```typescript
+import { redirectToLogin, redirectToLogout } from '@wristband/react-client-auth';
+
+// Login with tenant_domain in URL (backwards compatible)
+function handleLogin() {
+  redirectToLogin('https://your-server.com/api/auth/login?tenant_domain=acme-corp', {
+    tenantName: 'acme-corp',
+  });
+}
+
+// Logout with tenant_domain in URL (backwards compatible)
+function handleLogout() {
+  redirectToLogout('https://your-server.com/api/auth/logout?tenant_domain=acme-corp', {
+    tenantName: 'acme-corp',
+  });
+}
+```
+
+This allows you to upgrade the React SDK to v3.x while your backend remains on an older version. Once your backend is upgraded to support `tenantName`, migrate to using the config-based approach shown above.
+
+<br>
+
+---
+
+<br>
+
+## Type Changes: Enums to String Literal Unions
+
+Version 3.x converts `AuthStatus` and `WristbandErrorCode` from TypeScript enums to string literal union types. This change follows modern TypeScript best practices and provides better tree-shaking, zero runtime overhead, and simpler usage while still retaining IDE autocomplete and type checking.
+
+### AuthStatus
+
+**Before (v2.x):**
+```typescript
+import { AuthStatus, useWristbandAuth } from '@wristband/react-client-auth';
+
+function MyComponent() {
+  const { authStatus } = useWristbandAuth();
+  
+  if (authStatus === AuthStatus.LOADING) {
+    return <Spinner />;
+  }
+  
+  if (authStatus === AuthStatus.AUTHENTICATED) {
+    return <Dashboard />;
+  }
+  
+  return <LoginPrompt />;
+}
+```
+
+**After (v3.x):**
+```typescript
+import { useWristbandAuth } from '@wristband/react-client-auth';
+
+function MyComponent() {
+  const { authStatus } = useWristbandAuth();
+  
+  if (authStatus === 'LOADING') {
+    return <Spinner />;
+  }
+  
+  if (authStatus === 'AUTHENTICATED') {
+    return <Dashboard />;
+  }
+  
+  return <LoginPrompt />;
+}
+```
+
+**Key Changes:**
+- Replace `AuthStatus.LOADING` with `'LOADING'`
+- Replace `AuthStatus.AUTHENTICATED` with `'AUTHENTICATED'`
+- Replace `AuthStatus.UNAUTHENTICATED` with `'UNAUTHENTICATED'`
+- You no longer need to import `AuthStatus` unless you're using it for type annotations
+
+**Type Annotations (optional):**
+```typescript
+import { AuthStatus } from '@wristband/react-client-auth';
+
+const status: AuthStatus = 'LOADING';  // Still works for type safety
+```
+
+### WristbandErrorCode
+
+**Before (v2.x):**
+```typescript
+import { WristbandErrorCode, useWristbandAuth } from '@wristband/react-client-auth';
+
+function MyComponent() {
+  const { authError } = useWristbandAuth();
+  
+  if (authError?.code === WristbandErrorCode.UNAUTHENTICATED) {
+    // Handle unauthenticated error
+  }
+}
+```
+
+**After (v3.x):**
+```typescript
+import { useWristbandAuth } from '@wristband/react-client-auth';
+
+function MyComponent() {
+  const { authError } = useWristbandAuth();
+  
+  if (authError?.code === 'UNAUTHENTICATED') {
+    // Handle unauthenticated error
+  }
+}
+```
+
+**Key Changes:**
+- Use string literals directly: `'INVALID_LOGIN_URL'`, `'INVALID_LOGOUT_URL'`, `'INVALID_SESSION_RESPONSE'`, `'INVALID_SESSION_URL'`, `'INVALID_TOKEN_RESPONSE'`, `'INVALID_TOKEN_URL'`, `'SESSION_FETCH_FAILED'`, `'TOKEN_FETCH_FAILED'`, `'UNAUTHENTICATED'`
+- You no longer need to import `WristbandErrorCode` unless you're using it for type annotations
+
+**Type Annotations (optional):**
+```typescript
+import { WristbandErrorCode } from '@wristband/react-client-auth';
+
+const errorCode: WristbandErrorCode = 'UNAUTHENTICATED';  // Still works for type safety
+```
+
+<br>
+
+---
+
+<br>
+
+## Questions
+
+Reach out to the Wristband team at <support@wristband.dev> for any questions around migration.
+
+<br/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wristband/react-client-auth",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wristband/react-client-auth",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
@@ -14,9 +14,9 @@
         "@rollup/plugin-typescript": "^12.1.2",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
-        "@types/node": "^22.14.1",
-        "@types/react": "^18.3.20",
-        "@types/react-dom": "^18.3.6",
+        "@types/node": "^22.19.1",
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^7.5.0",
         "@typescript-eslint/parser": "^7.5.0",
         "@vitejs/plugin-react": "^4.3.4",
@@ -40,12 +40,12 @@
         "rollup-plugin-dts": "^6.2.1",
         "tslib": "^2.8.1",
         "typescript": "^5.8.3",
-        "vite": "^6.3.5",
+        "vite": "^6.4.1",
         "vitest": "^3.1.1"
       },
       "engines": {
-        "node": ">=18.12.1",
-        "npm": ">=8.19.2"
+        "node": ">=20.0.0",
+        "npm": ">=9.6.0"
       },
       "peerDependencies": {
         "react": ">=17.0.0",
@@ -2071,41 +2071,33 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
-      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.20",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
-      "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.6",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.6.tgz",
-      "integrity": "sha512-nf22//wEbKXusP6E9pfOCDwFdHAX4u172eaJI4YkDRQEZiorm6KfYnSC2SWLDMVWUOWPERmJnN0ujeAfTBLvrw==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -3429,9 +3421,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4965,9 +4957,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5874,9 +5866,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8193,9 +8185,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A lightweight React SDK that pairs with your backend server auth to initialize and sync frontend sessions via secure session cookies.",
   "author": "Wristband",
   "homepage": "https://wristband.dev",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "license": "MIT",
   "sideEffects": false,
   "type": "module",
@@ -33,8 +33,8 @@
     "email": "support@wristband.dev"
   },
   "engines": {
-    "node": ">=18.12.1",
-    "npm": ">=8.19.2"
+    "node": ">=20.0.0",
+    "npm": ">=9.6.0"
   },
   "publishConfig": {
     "access": "public"
@@ -77,9 +77,9 @@
     "@rollup/plugin-typescript": "^12.1.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
-    "@types/node": "^22.14.1",
-    "@types/react": "^18.3.20",
-    "@types/react-dom": "^18.3.6",
+    "@types/node": "^22.19.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^7.5.0",
     "@typescript-eslint/parser": "^7.5.0",
     "@vitejs/plugin-react": "^4.3.4",
@@ -103,7 +103,7 @@
     "rollup-plugin-dts": "^6.2.1",
     "tslib": "^2.8.1",
     "typescript": "^5.8.3",
-    "vite": "^6.3.5",
+    "vite": "^6.4.1",
     "vitest": "^3.1.1"
   }
 }

--- a/src/context/wristband-auth-provider.tsx
+++ b/src/context/wristband-auth-provider.tsx
@@ -1,13 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { WristbandAuthContext } from './wristband-auth-context';
-import {
-  AuthStatus,
-  IWristbandAuthProviderProps,
-  SessionResponse,
-  TokenResponse,
-  WristbandErrorCode,
-} from '../types/auth-provider-types';
+import { AuthStatus, IWristbandAuthProviderProps, SessionResponse, TokenResponse } from '../types/auth-provider-types';
 import apiClient from '../api/api-client';
 import {
   delay,
@@ -117,11 +111,7 @@ export function WristbandAuthProvider<TSessionMetaData = unknown>({
   const tokenRequestRef = useRef<Promise<string> | null>(null);
 
   // Convenience enum for users who don't want to check both isAuthenticated and isLoading
-  const authStatus: AuthStatus = isLoading
-    ? AuthStatus.LOADING
-    : isAuthenticated
-    ? AuthStatus.AUTHENTICATED
-    : AuthStatus.UNAUTHENTICATED;
+  const authStatus: AuthStatus = isLoading ? 'LOADING' : isAuthenticated ? 'AUTHENTICATED' : 'UNAUTHENTICATED';
 
   const { resolvedLoginUrl, validatedSessionUrl, validatedTokenUrl } = useMemo(() => {
     // All validations happen first before any useEffect
@@ -171,11 +161,11 @@ export function WristbandAuthProvider<TSessionMetaData = unknown>({
    */
   const getToken = useCallback(async (): Promise<string> => {
     if (!validatedTokenUrl || !validatedTokenUrl.trim()) {
-      throw new WristbandError(WristbandErrorCode.INVALID_TOKEN_URL, 'Token URL not configured');
+      throw new WristbandError('INVALID_TOKEN_URL', 'Token URL not configured');
     }
 
     if (!isAuthenticated) {
-      throw new WristbandError(WristbandErrorCode.UNAUTHENTICATED, 'User is not authenticated');
+      throw new WristbandError('UNAUTHENTICATED', 'User is not authenticated');
     }
 
     // Check if we have a valid cached token (with 30 second buffer)
@@ -200,14 +190,14 @@ export function WristbandAuthProvider<TSessionMetaData = unknown>({
 
             if (!newToken || !newToken.trim()) {
               throw new WristbandError(
-                WristbandErrorCode.INVALID_TOKEN_RESPONSE,
+                'INVALID_TOKEN_RESPONSE',
                 'Token Endpoint response is missing required field: "accessToken"'
               );
             }
 
             if (expiresAt === undefined || expiresAt === null || expiresAt < 0) {
               throw new WristbandError(
-                WristbandErrorCode.INVALID_TOKEN_RESPONSE,
+                'INVALID_TOKEN_RESPONSE',
                 'Token Endpoint response is missing required field: "expiresAt"'
               );
             }
@@ -227,12 +217,12 @@ export function WristbandAuthProvider<TSessionMetaData = unknown>({
             if (isUnauthorizedError(error)) {
               setAccessToken('');
               setAccessTokenExpiresAt(0);
-              throw new WristbandError(WristbandErrorCode.UNAUTHENTICATED, 'Token request unauthorized', error);
+              throw new WristbandError('UNAUTHENTICATED', 'Token request unauthorized', error);
             }
 
             // If it's any other 4xx error, bail early (don't retry client errors).
             if (is4xxError(error)) {
-              throw new WristbandError(WristbandErrorCode.TOKEN_FETCH_FAILED, 'Failed to fetch token', error);
+              throw new WristbandError('TOKEN_FETCH_FAILED', 'Failed to fetch token', error);
             }
 
             // If this is the last attempt, throw the last error
@@ -246,7 +236,7 @@ export function WristbandAuthProvider<TSessionMetaData = unknown>({
         }
 
         // All attempts failed, so throw an error
-        throw new WristbandError(WristbandErrorCode.TOKEN_FETCH_FAILED, 'Failed to fetch token', lastError);
+        throw new WristbandError('TOKEN_FETCH_FAILED', 'Failed to fetch token', lastError);
       } finally {
         // Clear the in-flight request
         tokenRequestRef.current = null;
@@ -277,14 +267,14 @@ export function WristbandAuthProvider<TSessionMetaData = unknown>({
 
           if (!userId || !userId.trim()) {
             throw new WristbandError(
-              WristbandErrorCode.INVALID_SESSION_RESPONSE,
+              'INVALID_SESSION_RESPONSE',
               'Session Endpoint response is missing required field: "userId"'
             );
           }
 
           if (!tenantId || !tenantId.trim()) {
             throw new WristbandError(
-              WristbandErrorCode.INVALID_SESSION_RESPONSE,
+              'INVALID_SESSION_RESPONSE',
               'Session Endpoint response is missing required field: "tenantId"'
             );
           }
@@ -315,19 +305,19 @@ export function WristbandAuthProvider<TSessionMetaData = unknown>({
           }
 
           if (isUnauthorizedError(error)) {
-            lastError = new WristbandError(WristbandErrorCode.UNAUTHENTICATED, 'User is not authenticated', error);
+            lastError = new WristbandError('UNAUTHENTICATED', 'User is not authenticated', error);
             break;
           }
 
           // If it's a non-401 4xx error, bail early (don't retry client errors)
           if (is4xxError(error)) {
-            lastError = new WristbandError(WristbandErrorCode.SESSION_FETCH_FAILED, 'Failed to fetch session', error);
+            lastError = new WristbandError('SESSION_FETCH_FAILED', 'Failed to fetch session', error);
             break;
           }
 
           // If this is the last attempt, don't delay
           if (attempt === MAX_API_ATTEMPTS) {
-            lastError = new WristbandError(WristbandErrorCode.SESSION_FETCH_FAILED, 'Failed to fetch session', error);
+            lastError = new WristbandError('SESSION_FETCH_FAILED', 'Failed to fetch session', error);
             break;
           }
 

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -41,10 +41,10 @@ export class ApiError extends Error {
  *
  * if (authError) {
  *   switch (authError.code) {
- *     case WristbandErrorCode.INVALID_SESSION_RESPONSE:
+ *     case 'INVALID_SESSION_RESPONSE':
  *       console.error('Session configuration error:', authError.message);
  *       break;
- *     case WristbandErrorCode.SESSION_FETCH_FAILED:
+ *     case 'SESSION_FETCH_FAILED':
  *       console.error('Session network error:', authError.message);
  *       break;
  *     default:
@@ -60,13 +60,13 @@ export class ApiError extends Error {
  * } catch (error) {
  *   if (error instanceof WristbandError) {
  *     switch (error.code) {
- *       case WristbandErrorCode.UNAUTHENTICATED:
+ *       case 'UNAUTHENTICATED':
  *         console.error('User not authenticated');
  *         break;
- *       case WristbandErrorCode.INVALID_TOKEN_RESPONSE:
+ *       case 'INVALID_TOKEN_RESPONSE':
  *         console.error('Token endpoint configuration error:', error.message);
  *         break;
- *       case WristbandErrorCode.TOKEN_FETCH_FAILED:
+ *       case 'TOKEN_FETCH_FAILED':
  *         console.error('Token network error:', error.message);
  *         break;
  *     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export { useWristbandSession } from './hooks/use-wristband-session';
 export { useWristbandToken } from './hooks/use-wristband-token';
 
 // Export types
-export { AuthStatus, WristbandErrorCode } from './types/auth-provider-types';
+export type { AuthStatus, WristbandErrorCode } from './types/auth-provider-types';
 export type { SessionResponse } from './types/auth-provider-types';
 export type { LoginRedirectConfig, LogoutRedirectConfig } from './types/util-types';
 
@@ -15,4 +15,4 @@ export type { LoginRedirectConfig, LogoutRedirectConfig } from './types/util-typ
 export { WristbandError } from './error';
 
 // Export utils
-export { redirectToLogin, redirectToLogout } from './utils/auth-utils';
+export { getCsrfToken, redirectToLogin, redirectToLogout } from './utils/auth-utils';

--- a/src/types/auth-provider-types.ts
+++ b/src/types/auth-provider-types.ts
@@ -3,26 +3,18 @@ import { PropsWithChildren } from 'react';
 import { WristbandError } from '../error';
 
 /**
- * Authentication status enum representing the possible states of user authentication.
+ * Authentication status representing the possible states of user authentication.
  *
- * This enum is used throughout the authentication flow to represent the current state
+ * This type is used throughout the authentication flow to represent the current state
  * of the authentication process and helps components determine what UI to display.
  */
-export enum AuthStatus {
-  /**
-   * The authentication state is currently being determined. This is the initial state during session validation.
-   */
-  LOADING = 'LOADING',
-  /**
-   * The user is successfully authenticated with a valid session. Protected resources can be accessed in this state.
-   */
-  AUTHENTICATED = 'AUTHENTICATED',
-  /**
-   * The user is not authenticated or the session is invalid. Access to protected resources should be denied in this
-   * state.
-   */
-  UNAUTHENTICATED = 'UNAUTHENTICATED',
-}
+export type AuthStatus =
+  /** The authentication state is currently being determined. This is the initial state during session validation. */
+  | 'LOADING'
+  /** The user is successfully authenticated with a valid session. Protected resources can be accessed in this state. */
+  | 'AUTHENTICATED'
+  /** The user is not authenticated or the session is invalid. Access to protected resources should be denied in this state. */
+  | 'UNAUTHENTICATED';
 
 /**
  * Context interface providing authentication state and session data throughout the application.
@@ -300,23 +292,22 @@ export interface TokenResponse {
 /**
  * Error codes for failures in the Wristband SDK.
  */
-export enum WristbandErrorCode {
+export type WristbandErrorCode =
   /** An invalid login URL value was provided to the SDK. */
-  INVALID_LOGIN_URL = 'INVALID_LOGIN_URL',
+  | 'INVALID_LOGIN_URL'
   /** An invalid logout URL value was provided to the SDK (primarily for `redirectToLogout()`). */
-  INVALID_LOGOUT_URL = 'INVALID_LOGOUT_URL',
+  | 'INVALID_LOGOUT_URL'
   /** The session endpoint response is missing required fields. */
-  INVALID_SESSION_RESPONSE = 'INVALID_SESSION_RESPONSE',
+  | 'INVALID_SESSION_RESPONSE'
   /** An invalid session URL value was provided to the SDK. */
-  INVALID_SESSION_URL = 'INVALID_SESSION_URL',
+  | 'INVALID_SESSION_URL'
   /** The token endpoint response is missing required fields. */
-  INVALID_TOKEN_RESPONSE = 'INVALID_TOKEN_RESPONSE',
+  | 'INVALID_TOKEN_RESPONSE'
   /** An invalid token URL value was provided to the SDK (only occurs if using `getToken()`). */
-  INVALID_TOKEN_URL = 'INVALID_TOKEN_URL',
+  | 'INVALID_TOKEN_URL'
   /** The session endpoint returned an error other than 401. */
-  SESSION_FETCH_FAILED = 'SESSION_FETCH_FAILED',
+  | 'SESSION_FETCH_FAILED'
   /** The token endpoint returned an error other than 401. */
-  TOKEN_FETCH_FAILED = 'TOKEN_FETCH_FAILED',
+  | 'TOKEN_FETCH_FAILED'
   /** The user is not authenticated and cannot request a session or token. */
-  UNAUTHENTICATED = 'UNAUTHENTICATED',
-}
+  | 'UNAUTHENTICATED';

--- a/src/types/util-types.ts
+++ b/src/types/util-types.ts
@@ -22,9 +22,9 @@ export interface LoginRedirectConfig {
    */
   returnUrl?: string;
   /**
-   * Optional tenant domain name for directing users to the correct Tenant Login Page.
+   * Optional tenant name for directing users to the correct Tenant Login Page.
    *
-   * When provided, this value is sent as the "tenant_domain" query parameter to your backend server's Login Ednpoint,
+   * When provided, this value is sent as the "tenant_name" query parameter to your backend server's Login Ednpoint,
    * enabling automatic tenant routing during login.
    *
    * This parameter is primarily useful when:
@@ -33,7 +33,7 @@ export interface LoginRedirectConfig {
    *
    * @example "acme-corp" // Directs to Acme Corporation's Tenant Login Page
    */
-  tenantDomain?: string;
+  tenantName?: string;
   /**
    * Optional tenant custom domain for directing users to the correct Tenant Login Page.
    *
@@ -55,9 +55,9 @@ export interface LoginRedirectConfig {
  */
 export interface LogoutRedirectConfig {
   /**
-   * Optional tenant domain name for directing users to the correct Tenant Login Page.
+   * Optional tenant name for directing users to the correct Tenant Login Page.
    *
-   * When provided, this value is sent as the "tenant_domain" query parameter to your backend server's Logout Ednpoint,
+   * When provided, this value is sent as the "tenant_name" query parameter to your backend server's Logout Ednpoint,
    * enabling automatic tenant routing during logout.
    *
    * This parameter is primarily useful when:
@@ -66,7 +66,7 @@ export interface LogoutRedirectConfig {
    *
    * @example "acme-corp" // Directs to Acme Corporation's Tenant Login Page
    */
-  tenantDomain?: string;
+  tenantName?: string;
 
   /**
    * Optional tenant custom domain for directing users to the correct Tenant Login Page.

--- a/src/utils/auth-provider-utils.ts
+++ b/src/utils/auth-provider-utils.ts
@@ -1,5 +1,4 @@
 import { ApiError, WristbandError } from '../error';
-import { WristbandErrorCode } from '../types/auth-provider-types';
 
 /**
  * Resolves and properly formats a login URL for the Wristband Auth Provider.
@@ -24,7 +23,7 @@ import { WristbandErrorCode } from '../types/auth-provider-types';
  */
 export function resolveAuthProviderLoginUrl(loginUrl: string): string {
   if (!loginUrl || !loginUrl.trim()) {
-    throw new WristbandError(WristbandErrorCode.INVALID_LOGIN_URL, 'WristbandAuthProvider: [loginUrl] is required');
+    throw new WristbandError('INVALID_LOGIN_URL', 'WristbandAuthProvider: [loginUrl] is required');
   }
 
   // For frameworks like NextJS, need to ensure this doesn't break in server-side environments.
@@ -36,10 +35,7 @@ export function resolveAuthProviderLoginUrl(loginUrl: string): string {
   try {
     resolvedUrl = new URL(loginUrl, window.location.origin);
   } catch {
-    throw new WristbandError(
-      WristbandErrorCode.INVALID_LOGIN_URL,
-      `WristbandAuthProvider: [${loginUrl}] is not a valid loginUrl`
-    );
+    throw new WristbandError('INVALID_LOGIN_URL', `WristbandAuthProvider: [${loginUrl}] is not a valid loginUrl`);
   }
 
   // If return_url is not present, add it.
@@ -71,7 +67,7 @@ export function resolveAuthProviderLoginUrl(loginUrl: string): string {
  */
 export function validateAuthProviderSessionUrl(sessionUrl: string): void {
   if (!sessionUrl || !sessionUrl.trim()) {
-    throw new WristbandError(WristbandErrorCode.INVALID_SESSION_URL, 'WristbandAuthProvider: [sessionUrl] is required');
+    throw new WristbandError('INVALID_SESSION_URL', 'WristbandAuthProvider: [sessionUrl] is required');
   }
 
   // For frameworks like NextJS, need to ensure this doesn't break in server-side environments.
@@ -80,7 +76,7 @@ export function validateAuthProviderSessionUrl(sessionUrl: string): void {
       new URL(sessionUrl, window.location.origin);
     } catch {
       throw new WristbandError(
-        WristbandErrorCode.INVALID_SESSION_URL,
+        'INVALID_SESSION_URL',
         `WristbandAuthProvider: [${sessionUrl}] is not a valid sessionUrl`
       );
     }
@@ -112,10 +108,7 @@ export function validateAuthProviderTokenUrl(tokenUrl?: string): void {
     try {
       new URL(tokenUrl, window.location.origin);
     } catch {
-      throw new WristbandError(
-        WristbandErrorCode.INVALID_TOKEN_URL,
-        `WristbandAuthProvider: [${tokenUrl}] is not a valid tokenUrl`
-      );
+      throw new WristbandError('INVALID_TOKEN_URL', `WristbandAuthProvider: [${tokenUrl}] is not a valid tokenUrl`);
     }
   }
 }

--- a/src/utils/auth-utils.ts
+++ b/src/utils/auth-utils.ts
@@ -1,9 +1,9 @@
 import { WristbandError } from '../error';
 import { LoginRedirectConfig, LogoutRedirectConfig } from '../types/util-types';
-import { WristbandErrorCode } from '../types/auth-provider-types';
 
-const reservedLoginQueryKeys = ['login_hint', 'return_url', 'tenant_domain', 'tenant_custom_domain'];
-const reservedLogoutQueryKeys = ['tenant_domain', 'tenant_custom_domain'];
+const defaultCsrfCookieName = 'CSRF-TOKEN';
+const reservedLoginQueryKeys = ['login_hint', 'return_url', 'tenant_name', 'tenant_custom_domain'];
+const reservedLogoutQueryKeys = ['tenant_name', 'tenant_custom_domain'];
 
 /**
  * Redirects the user to your backend server's Login Endpoint with optional configuration parameters (browser only).
@@ -14,73 +14,72 @@ const reservedLogoutQueryKeys = ['tenant_domain', 'tenant_custom_domain'];
  *
  * @param {string} loginUrl - The login endpoint URL that handles authentication
  * @param {LoginRedirectConfig} config - Optional configuration for customizing the login experience
- * @returns {Promise<void>} A promise that resolves when the redirect is triggered
+ * @returns {void}
  * @throws {WristbandError} If loginUrl is undefined, null, or empty.
  *
  * @example
  * // Basic redirect to login endpoint
- * await redirectToLogin('/api/auth/login');
+ * redirectToLogin('/api/auth/login');
  *
  * @example
  * // Redirect with pre-filled email address
- * await redirectToLogin('/api/auth/login', {
+ * redirectToLogin('/api/auth/login', {
  *   loginHint: 'user@example.com'
  * });
  *
  * @example
- * // Redirect with custom return destination and tenant domain
- * await redirectToLogin('/api/auth/login', {
+ * // Redirect with custom return destination and tenant name
+ * redirectToLogin('/api/auth/login', {
  *   returnUrl: 'https://app.example.com/dashboard',
- *   tenantDomain: 'acme-corp'
+ *   tenantName: 'acme-corp'
  * });
  *
  * @example
- * // Redirect with custom return destination and tenant domain
- * await redirectToLogin('/api/auth/login', {
+ * // Redirect with custom return destination and tenant custom domain
+ * redirectToLogin('/api/auth/login', {
  *   returnUrl: 'https://app.example.com/dashboard',
  *   tenantCustomDomain: 'auth.acme.com'
  * });
  */
-export function redirectToLogin(loginUrl: string, config: LoginRedirectConfig = {}) {
-  if (!loginUrl) {
-    throw new WristbandError(WristbandErrorCode.INVALID_LOGIN_URL, 'Redirect To Login: "loginUrl" is required');
+export function redirectToLogin(loginUrl: string, config: LoginRedirectConfig = {}): void {
+  if (!loginUrl || !loginUrl.trim()) {
+    throw new WristbandError('INVALID_LOGIN_URL', 'Redirect To Login: "loginUrl" is required');
   }
 
   // For frameworks like NextJS, need to ensure this can only be attempted in the browser.
-  if (typeof window !== 'undefined') {
-    let resolvedUrl: URL;
-    try {
-      resolvedUrl = new URL(loginUrl, window.location.origin);
-    } catch {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  let resolvedUrl: URL;
+  try {
+    resolvedUrl = new URL(loginUrl, window.location.origin);
+  } catch {
+    throw new WristbandError('INVALID_LOGIN_URL', `Redirect To Login: "${loginUrl}" is not a valid login URL`);
+  }
+
+  reservedLoginQueryKeys.forEach((key) => {
+    if (resolvedUrl.searchParams.has(key)) {
       throw new WristbandError(
-        WristbandErrorCode.INVALID_LOGIN_URL,
-        `Redirect To Login: "${loginUrl}" is not a valid login URL`
+        'INVALID_LOGIN_URL',
+        `Redirect To Login: loginUrl must not include reserved query param: "${key}"`
       );
     }
+  });
 
-    for (const key of reservedLoginQueryKeys) {
-      if (resolvedUrl.searchParams.has(key)) {
-        throw new WristbandError(
-          WristbandErrorCode.INVALID_LOGIN_URL,
-          `Redirect To Login: loginUrl must not include reserved query param: "${key}"`
-        );
-      }
-    }
+  const queryParams: URLSearchParams = new URLSearchParams({
+    ...(config.loginHint ? { login_hint: config.loginHint } : {}),
+    ...(config.returnUrl ? { return_url: encodeURI(config.returnUrl) } : {}),
+    ...(config.tenantName ? { tenant_name: config.tenantName } : {}),
+    ...(config.tenantCustomDomain ? { tenant_custom_domain: config.tenantCustomDomain } : {}),
+  });
 
-    const queryParams: URLSearchParams = new URLSearchParams({
-      ...(config.loginHint ? { login_hint: config.loginHint } : {}),
-      ...(config.returnUrl ? { return_url: encodeURI(config.returnUrl) } : {}),
-      ...(config.tenantDomain ? { tenant_domain: config.tenantDomain } : {}),
-      ...(config.tenantCustomDomain ? { tenant_custom_domain: config.tenantCustomDomain } : {}),
-    });
+  resolvedUrl.searchParams.forEach((value, key) => {
+    queryParams.append(key, value);
+  });
 
-    resolvedUrl.searchParams.forEach((value, key) => {
-      queryParams.append(key, value);
-    });
-
-    resolvedUrl.search = queryParams.toString();
-    window.location.href = resolvedUrl.toString();
-  }
+  resolvedUrl.search = queryParams.toString();
+  window.location.href = resolvedUrl.toString();
 }
 
 /**
@@ -90,61 +89,108 @@ export function redirectToLogin(loginUrl: string, config: LoginRedirectConfig = 
  *
  * @param {string} logoutUrl - The URL of your server's Logout Endpoint
  * @param {LogoutRedirectConfig} config - Optional configuration for the logout redirect
- * @returns {Promise<void>} A promise that resolves when the redirect is triggered
  * @throws {WristbandError} If logoutUrl is undefined, null, or empty.
  *
  * @example
  * // Basic redirect to logout endpoint
- * await redirectToLogout('/api/auth/logout');
+ * redirectToLogout('/api/auth/logout');
  *
  * @example
- * // Redirect with tenant domain parameter
- * await redirectToLogout('/api/auth/logout', {
- *   tenantDomain: 'acme-corp'
+ * // Redirect with tenant name parameter
+ * redirectToLogout('/api/auth/logout', {
+ *   tenantName: 'acme-corp'
  * });
  *
  * @example
- * // Redirect with tenant domain parameter
- * await redirectToLogout('/api/auth/logout', {
+ * // Redirect with tenant custom domain parameter
+ * redirectToLogout('/api/auth/logout', {
  *   tenantCustomDomain: 'auth.acme.com'
  * });
  */
 export function redirectToLogout(logoutUrl: string, config: LogoutRedirectConfig = {}) {
-  if (!logoutUrl) {
-    throw new WristbandError(WristbandErrorCode.INVALID_LOGOUT_URL, 'Redirect To Logout: "logoutUrl" is required');
+  if (!logoutUrl || !logoutUrl.trim()) {
+    throw new WristbandError('INVALID_LOGOUT_URL', 'Redirect To Logout: "logoutUrl" is required');
   }
 
   // For frameworks like NextJS, need to ensure this can only be attempted in the browser.
-  if (typeof window !== 'undefined') {
-    let resolvedUrl: URL;
-    try {
-      resolvedUrl = new URL(logoutUrl, window.location.origin);
-    } catch {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  let resolvedUrl: URL;
+  try {
+    resolvedUrl = new URL(logoutUrl, window.location.origin);
+  } catch {
+    throw new WristbandError('INVALID_LOGOUT_URL', `Redirect To Logout: "${logoutUrl}" is not a valid logout URL`);
+  }
+
+  for (const key of reservedLogoutQueryKeys) {
+    if (resolvedUrl.searchParams.has(key)) {
       throw new WristbandError(
-        WristbandErrorCode.INVALID_LOGOUT_URL,
-        `Redirect To Logout: "${logoutUrl}" is not a valid logout URL`
+        'INVALID_LOGOUT_URL',
+        `Redirect To Logout: logoutUrl must not include reserved query param: "${key}"`
       );
     }
-
-    for (const key of reservedLogoutQueryKeys) {
-      if (resolvedUrl.searchParams.has(key)) {
-        throw new WristbandError(
-          WristbandErrorCode.INVALID_LOGOUT_URL,
-          `Redirect To Logout: logoutUrl must not include reserved query param: "${key}"`
-        );
-      }
-    }
-
-    const queryParams: URLSearchParams = new URLSearchParams({
-      ...(config.tenantDomain ? { tenant_domain: config.tenantDomain } : {}),
-      ...(config.tenantCustomDomain ? { tenant_custom_domain: config.tenantCustomDomain } : {}),
-    });
-
-    resolvedUrl.searchParams.forEach((value, key) => {
-      queryParams.append(key, value);
-    });
-
-    resolvedUrl.search = queryParams.toString();
-    window.location.href = resolvedUrl.toString();
   }
+
+  const queryParams: URLSearchParams = new URLSearchParams({
+    ...(config.tenantName ? { tenant_name: config.tenantName } : {}),
+    ...(config.tenantCustomDomain ? { tenant_custom_domain: config.tenantCustomDomain } : {}),
+  });
+
+  resolvedUrl.searchParams.forEach((value, key) => {
+    queryParams.append(key, value);
+  });
+
+  resolvedUrl.search = queryParams.toString();
+  window.location.href = resolvedUrl.toString();
+}
+
+/**
+ * Retrieves the CSRF token from the specified cookie.
+ *
+ * This utility is helpful when using the Fetch API or other HTTP clients
+ * that don't automatically handle CSRF tokens. Use this to extract the token
+ * and include it in your request headers.
+ *
+ * @param {string} cookieName - The name of the CSRF cookie (default: 'CSRF-TOKEN')
+ * @returns {string | undefined} The CSRF token value, or undefined if the cookie is not found
+ *
+ * @example
+ * ```typescript
+ * import { getCsrfToken } from '@wristband/react-client-auth';
+ *
+ * async function makeApiCall() {
+ *   const csrfToken = getCsrfToken();
+ *
+ *   const response = await fetch('/api/endpoint', {
+ *     method: 'POST',
+ *     credentials: 'include',
+ *     headers: {
+ *       'Content-Type': 'application/json',
+ *       'X-CSRF-TOKEN': csrfToken ?? ''
+ *     },
+ *     body: JSON.stringify({ data: 'example' })
+ *   });
+ *
+ *   if (!response.ok) {
+ *     if ([401, 403].includes(response.status)) {
+ *       window.location.href = '/api/auth/login';
+ *       return;
+ *     }
+ *     throw new Error(`HTTP error! status: ${response.status}`);
+ *   }
+ *
+ *   return await response.json();
+ * }
+ * ```
+ */
+export function getCsrfToken(cookieName?: string): string | undefined {
+  // For frameworks like NextJS, need to ensure this can only be attempted in the browser.
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  const match = document.cookie.match(new RegExp('(^|;\\s*)' + (cookieName ?? defaultCsrfCookieName) + '=([^;]*)'));
+  return match ? decodeURIComponent(match[2]) : undefined;
 }

--- a/src/utils/auth-utils.ts
+++ b/src/utils/auth-utils.ts
@@ -124,14 +124,14 @@ export function redirectToLogout(logoutUrl: string, config: LogoutRedirectConfig
     throw new WristbandError('INVALID_LOGOUT_URL', `Redirect To Logout: "${logoutUrl}" is not a valid logout URL`);
   }
 
-  for (const key of reservedLogoutQueryKeys) {
+  reservedLogoutQueryKeys.forEach((key) => {
     if (resolvedUrl.searchParams.has(key)) {
       throw new WristbandError(
         'INVALID_LOGOUT_URL',
         `Redirect To Logout: logoutUrl must not include reserved query param: "${key}"`
       );
     }
-  }
+  });
 
   const queryParams: URLSearchParams = new URLSearchParams({
     ...(config.tenantName ? { tenant_name: config.tenantName } : {}),

--- a/test/context/wristband-auth-context.test.tsx
+++ b/test/context/wristband-auth-context.test.tsx
@@ -3,15 +3,15 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 import { WristbandAuthContext } from '../../src/context/wristband-auth-context';
-import { AuthStatus } from '../../src/types/auth-provider-types';
+import { IWristbandAuthContext } from '../../src/types/auth-provider-types';
 
 describe('WristbandAuthContext', () => {
   it('provides context values to consuming components', () => {
     // Mock context values
-    const contextValue = {
+    const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'test-user-id',
       tenantId: 'test-tenant-id',
@@ -41,7 +41,7 @@ describe('WristbandAuthContext', () => {
     );
 
     // Assert context values are correctly consumed
-    expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.AUTHENTICATED.toString());
+    expect(screen.getByTestId('auth-status').textContent).toBe('AUTHENTICATED');
     expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
   });
 

--- a/test/context/wristband-auth-provider.test.tsx
+++ b/test/context/wristband-auth-provider.test.tsx
@@ -5,7 +5,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { WristbandAuthProvider } from '../../src/context/wristband-auth-provider';
 import { WristbandAuthContext } from '../../src/context/wristband-auth-context';
 import apiClient from '../../src/api/api-client';
-import { AuthStatus } from '../../src/types/auth-provider-types';
 import * as authProviderUtils from '../../src/utils/auth-provider-utils';
 import { ApiError } from '../../src/error';
 
@@ -79,7 +78,7 @@ describe('WristbandAuthProvider', () => {
   // Store original console methods
   const originalConsoleLog = console.log;
   const originalConsoleError = console.error;
-  let restoreLocation;
+  let restoreLocation: () => void;
 
   beforeEach(() => {
     // Mock window.location
@@ -140,7 +139,7 @@ describe('WristbandAuthProvider', () => {
     );
 
     expect(screen.getByTestId('auth-error').textContent).toBe('null');
-    expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.LOADING.toString());
+    expect(screen.getByTestId('auth-status').textContent).toBe('LOADING');
     expect(screen.getByTestId('is-loading').textContent).toBe('true');
     expect(screen.getByTestId('is-authenticated').textContent).toBe('false');
   });
@@ -166,7 +165,7 @@ describe('WristbandAuthProvider', () => {
     // Wait for session to be fetched
     await waitFor(() => {
       expect(screen.getByTestId('auth-error').textContent).toBe('null');
-      expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.AUTHENTICATED.toString());
+      expect(screen.getByTestId('auth-status').textContent).toBe('AUTHENTICATED');
       expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
       expect(screen.getByTestId('is-loading').textContent).toBe('false');
       expect(screen.getByTestId('user-id').textContent).toBe('user-123');
@@ -392,7 +391,7 @@ describe('WristbandAuthProvider', () => {
       expect(screen.getByTestId('auth-error').textContent).toBe('null');
       expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
       expect(screen.getByTestId('is-loading').textContent).toBe('false');
-      expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.AUTHENTICATED.toString());
+      expect(screen.getByTestId('auth-status').textContent).toBe('AUTHENTICATED');
       expect(screen.getByTestId('user-id').textContent).toBe('user-123');
       expect(screen.getByTestId('tenant-id').textContent).toBe('tenant-456');
       expect(JSON.parse(screen.getByTestId('metadata').textContent || '{}')).toEqual(mockSessionData.metadata);
@@ -420,7 +419,7 @@ describe('WristbandAuthProvider', () => {
       expect(screen.getByTestId('auth-error').textContent).toBe('null');
       expect(screen.getByTestId('is-authenticated').textContent).toBe('false');
       expect(screen.getByTestId('is-loading').textContent).toBe('false');
-      expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.UNAUTHENTICATED.toString());
+      expect(screen.getByTestId('auth-status').textContent).toBe('UNAUTHENTICATED');
       expect(screen.getByTestId('user-id').textContent).toBe('no-user-id');
       expect(screen.getByTestId('tenant-id').textContent).toBe('no-tenant-id');
       expect(screen.getByTestId('metadata').textContent).toBe('{}');
@@ -575,7 +574,7 @@ describe('WristbandAuthProvider', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('auth-error').textContent).toBe('null');
-      expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.AUTHENTICATED.toString());
+      expect(screen.getByTestId('auth-status').textContent).toBe('AUTHENTICATED');
       expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
       expect(screen.getByTestId('is-loading').textContent).toBe('false');
       expect(screen.getByTestId('user-id').textContent).toBe('user-123');
@@ -597,7 +596,7 @@ describe('WristbandAuthProvider', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('auth-error').textContent).toBe('null');
-      expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.AUTHENTICATED.toString());
+      expect(screen.getByTestId('auth-status').textContent).toBe('AUTHENTICATED');
       expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
       expect(screen.getByTestId('is-loading').textContent).toBe('false');
       expect(screen.getByTestId('user-id').textContent).toBe('user-123');
@@ -619,7 +618,7 @@ describe('WristbandAuthProvider', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('auth-error').textContent).toBe('null');
-      expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.AUTHENTICATED.toString());
+      expect(screen.getByTestId('auth-status').textContent).toBe('AUTHENTICATED');
       expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
       expect(screen.getByTestId('is-loading').textContent).toBe('false');
       expect(screen.getByTestId('user-id').textContent).toBe('user-123');
@@ -645,7 +644,7 @@ describe('WristbandAuthProvider', () => {
         expect(window.location.href).toBe('https://current-page.com/path');
         expect(screen.getByTestId('auth-error').textContent).toBe('User is not authenticated');
         expect(screen.getByTestId('auth-error-code').textContent).toBe('UNAUTHENTICATED');
-        expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.UNAUTHENTICATED.toString());
+        expect(screen.getByTestId('auth-status').textContent).toBe('UNAUTHENTICATED');
         expect(screen.getByTestId('is-authenticated').textContent).toBe('false');
         expect(screen.getByTestId('is-loading').textContent).toBe('false');
       });
@@ -666,7 +665,7 @@ describe('WristbandAuthProvider', () => {
       await waitFor(() => {
         expect(screen.getByTestId('auth-error').textContent).toBe('Failed to fetch session');
         expect(screen.getByTestId('auth-error-code').textContent).toBe('SESSION_FETCH_FAILED');
-        expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.UNAUTHENTICATED.toString());
+        expect(screen.getByTestId('auth-status').textContent).toBe('UNAUTHENTICATED');
         expect(screen.getByTestId('is-authenticated').textContent).toBe('false');
         expect(screen.getByTestId('is-loading').textContent).toBe('false');
       });
@@ -687,7 +686,7 @@ describe('WristbandAuthProvider', () => {
       await waitFor(() => {
         expect(screen.getByTestId('auth-error').textContent).toBe('Failed to fetch session');
         expect(screen.getByTestId('auth-error-code').textContent).toBe('SESSION_FETCH_FAILED');
-        expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.UNAUTHENTICATED.toString());
+        expect(screen.getByTestId('auth-status').textContent).toBe('UNAUTHENTICATED');
         expect(screen.getByTestId('is-authenticated').textContent).toBe('false');
         expect(screen.getByTestId('is-loading').textContent).toBe('false');
       });
@@ -711,7 +710,7 @@ describe('WristbandAuthProvider', () => {
       await waitFor(() => {
         expect(screen.getByTestId('auth-error').textContent).toBe('no-error');
         expect(screen.getByTestId('auth-error-code').textContent).toBe('no-code');
-        expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.AUTHENTICATED.toString());
+        expect(screen.getByTestId('auth-status').textContent).toBe('AUTHENTICATED');
         expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
         expect(screen.getByTestId('is-loading').textContent).toBe('false');
       });
@@ -757,7 +756,7 @@ describe('WristbandAuthProvider', () => {
       await waitFor(() => {
         expect(screen.getByTestId('auth-error').textContent).toBe('no-error');
         expect(screen.getByTestId('auth-error-code').textContent).toBe('no-code');
-        expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.UNAUTHENTICATED.toString());
+        expect(screen.getByTestId('auth-status').textContent).toBe('UNAUTHENTICATED');
       });
     });
 
@@ -1715,7 +1714,7 @@ describe('WristbandAuthProvider', () => {
 
       // Should eventually succeed and become authenticated
       await waitFor(() => {
-        expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.AUTHENTICATED.toString());
+        expect(screen.getByTestId('auth-status').textContent).toBe('AUTHENTICATED');
         expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
         expect(screen.getByTestId('is-loading').textContent).toBe('false');
         expect(screen.getByTestId('user-id').textContent).toBe('user-123');
@@ -1830,7 +1829,7 @@ describe('WristbandAuthProvider', () => {
 
       // Should eventually succeed after retries
       await waitFor(() => {
-        expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.AUTHENTICATED.toString());
+        expect(screen.getByTestId('auth-status').textContent).toBe('AUTHENTICATED');
         expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
         expect(screen.getByTestId('is-loading').textContent).toBe('false');
       });
@@ -1881,7 +1880,7 @@ describe('WristbandAuthProvider', () => {
       await waitFor(() => {
         // Should not redirect, should set to unauthenticated state
         expect(window.location.href).toBe('https://current-page.com/path');
-        expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.UNAUTHENTICATED.toString());
+        expect(screen.getByTestId('auth-status').textContent).toBe('UNAUTHENTICATED');
         expect(screen.getByTestId('is-authenticated').textContent).toBe('false');
         expect(screen.getByTestId('is-loading').textContent).toBe('false');
       });
@@ -1909,7 +1908,7 @@ describe('WristbandAuthProvider', () => {
       await waitFor(() => {
         // Should not redirect, should set to unauthenticated state
         expect(window.location.href).toBe('https://current-page.com/path');
-        expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.UNAUTHENTICATED.toString());
+        expect(screen.getByTestId('auth-status').textContent).toBe('UNAUTHENTICATED');
         expect(screen.getByTestId('is-authenticated').textContent).toBe('false');
         expect(screen.getByTestId('is-loading').textContent).toBe('false');
       });

--- a/test/error/index.test.ts
+++ b/test/error/index.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
 import { ApiError, WristbandError } from '../../src/error';
-import { WristbandErrorCode } from '../../src/types/auth-provider-types';
 
 describe('ApiError', () => {
   it('should create an ApiError with correct name and message', () => {
@@ -23,7 +22,7 @@ describe('ApiError', () => {
 
 describe('WristbandError', () => {
   it('should create an error with UNAUTHENTICATED code', () => {
-    const error = new WristbandError(WristbandErrorCode.UNAUTHENTICATED, 'User not authenticated');
+    const error = new WristbandError('UNAUTHENTICATED', 'User not authenticated');
     expect(error).toBeInstanceOf(WristbandError);
     expect(error.name).toBe('WristbandError');
     expect(error.code).toBe('UNAUTHENTICATED');
@@ -33,21 +32,21 @@ describe('WristbandError', () => {
 
   it('should create an error with TOKEN_FETCH_FAILED code and original error', () => {
     const original = new Error('Something bad happened');
-    const error = new WristbandError(WristbandErrorCode.TOKEN_FETCH_FAILED, 'Token fetch failed', original);
+    const error = new WristbandError('TOKEN_FETCH_FAILED', 'Token fetch failed', original);
     expect(error.code).toBe('TOKEN_FETCH_FAILED');
     expect(error.message).toBe('Token fetch failed');
     expect(error.originalError).toBe(original);
   });
 
   it('should create an error with INVALID_TOKEN_URL code', () => {
-    const error = new WristbandError(WristbandErrorCode.INVALID_TOKEN_URL, 'Token URL missing');
+    const error = new WristbandError('INVALID_TOKEN_URL', 'Token URL missing');
     expect(error.code).toBe('INVALID_TOKEN_URL');
     expect(error.message).toBe('Token URL missing');
   });
 
   it('should create an error with INVALID_TOKEN_RESPONSE code', () => {
     const error = new WristbandError(
-      WristbandErrorCode.INVALID_TOKEN_RESPONSE,
+      'INVALID_TOKEN_RESPONSE',
       'Token Endpoint response is missing required field: "accessToken"'
     );
     expect(error.code).toBe('INVALID_TOKEN_RESPONSE');
@@ -55,32 +54,32 @@ describe('WristbandError', () => {
   });
 
   it('should create an error with INVALID_LOGIN_URL code', () => {
-    const error = new WristbandError(WristbandErrorCode.INVALID_LOGIN_URL, 'Login URL missing');
+    const error = new WristbandError('INVALID_LOGIN_URL', 'Login URL missing');
     expect(error.code).toBe('INVALID_LOGIN_URL');
     expect(error.message).toBe('Login URL missing');
   });
 
   it('should create an error with INVALID_LOGOUT_URL code', () => {
-    const error = new WristbandError(WristbandErrorCode.INVALID_LOGOUT_URL, 'Logout URL missing');
+    const error = new WristbandError('INVALID_LOGOUT_URL', 'Logout URL missing');
     expect(error.code).toBe('INVALID_LOGOUT_URL');
     expect(error.message).toBe('Logout URL missing');
   });
 
   it('should create an error with INVALID_SESSION_URL code', () => {
-    const error = new WristbandError(WristbandErrorCode.INVALID_SESSION_URL, 'Session URL missing');
+    const error = new WristbandError('INVALID_SESSION_URL', 'Session URL missing');
     expect(error.code).toBe('INVALID_SESSION_URL');
     expect(error.message).toBe('Session URL missing');
   });
 
   it('should create an error with SESSION_FETCH_FAILED code', () => {
-    const error = new WristbandError(WristbandErrorCode.SESSION_FETCH_FAILED, 'Session fetch failed');
+    const error = new WristbandError('SESSION_FETCH_FAILED', 'Session fetch failed');
     expect(error.code).toBe('SESSION_FETCH_FAILED');
     expect(error.message).toBe('Session fetch failed');
   });
 
   it('should create an error with INVALID_SESSION_RESPONSE code', () => {
     const error = new WristbandError(
-      WristbandErrorCode.INVALID_SESSION_RESPONSE,
+      'INVALID_SESSION_RESPONSE',
       'Session Endpoint response is missing required field: "userId"'
     );
     expect(error.code).toBe('INVALID_SESSION_RESPONSE');
@@ -90,7 +89,7 @@ describe('WristbandError', () => {
   it('should create an error with SESSION_FETCH_FAILED code and original error', () => {
     const original = new ApiError('Server Error');
     original.status = 500;
-    const error = new WristbandError(WristbandErrorCode.SESSION_FETCH_FAILED, 'Session fetch failed', original);
+    const error = new WristbandError('SESSION_FETCH_FAILED', 'Session fetch failed', original);
     expect(error.code).toBe('SESSION_FETCH_FAILED');
     expect(error.message).toBe('Session fetch failed');
     expect(error.originalError).toBe(original);
@@ -98,7 +97,7 @@ describe('WristbandError', () => {
 
   it('should create an error with INVALID_SESSION_RESPONSE code and original error', () => {
     const original = { missingField: 'userId' };
-    const error = new WristbandError(WristbandErrorCode.INVALID_SESSION_RESPONSE, 'Invalid session response', original);
+    const error = new WristbandError('INVALID_SESSION_RESPONSE', 'Invalid session response', original);
     expect(error.code).toBe('INVALID_SESSION_RESPONSE');
     expect(error.message).toBe('Invalid session response');
     expect(error.originalError).toBe(original);

--- a/test/hooks/use-wristband-auth.test.tsx
+++ b/test/hooks/use-wristband-auth.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, renderHook } from '@testing-library/react';
 
 import { useWristbandAuth } from '../../src/hooks/use-wristband-auth';
 import { WristbandAuthContext } from '../../src/context/wristband-auth-context';
-import { AuthStatus, IWristbandAuthContext, WristbandErrorCode } from '../../src/types/auth-provider-types';
+import { IWristbandAuthContext } from '../../src/types/auth-provider-types';
 import { WristbandError } from '../../src/error';
 
 describe('useWristbandAuth', () => {
@@ -19,7 +19,7 @@ describe('useWristbandAuth', () => {
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',
@@ -43,7 +43,7 @@ describe('useWristbandAuth', () => {
       authError: null,
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       clearAuthData: mockClearAuthData,
     });
 
@@ -59,7 +59,7 @@ describe('useWristbandAuth', () => {
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',
@@ -119,7 +119,7 @@ describe('useWristbandAuth', () => {
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',
@@ -138,7 +138,7 @@ describe('useWristbandAuth', () => {
     );
 
     // The component should render with the correct values
-    expect(screen.getByTestId('auth-status').textContent).toBe(AuthStatus.AUTHENTICATED.toString());
+    expect(screen.getByTestId('auth-status').textContent).toBe('AUTHENTICATED');
     expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
     expect(screen.getByTestId('is-loading').textContent).toBe('false');
 
@@ -156,7 +156,7 @@ describe('useWristbandAuth', () => {
         contextValue: {
           isAuthenticated: false,
           isLoading: true,
-          authStatus: AuthStatus.LOADING,
+          authStatus: 'LOADING',
           authError: null,
           userId: '',
           tenantId: '',
@@ -170,7 +170,7 @@ describe('useWristbandAuth', () => {
           authError: null,
           isAuthenticated: false,
           isLoading: true,
-          authStatus: AuthStatus.LOADING,
+          authStatus: 'LOADING',
           clearAuthData: expect.any(Function),
         },
       },
@@ -178,7 +178,7 @@ describe('useWristbandAuth', () => {
         contextValue: {
           isAuthenticated: true,
           isLoading: false,
-          authStatus: AuthStatus.AUTHENTICATED,
+          authStatus: 'AUTHENTICATED',
           authError: null,
           userId: 'user-123',
           tenantId: 'tenant-456',
@@ -192,7 +192,7 @@ describe('useWristbandAuth', () => {
           authError: null,
           isAuthenticated: true,
           isLoading: false,
-          authStatus: AuthStatus.AUTHENTICATED,
+          authStatus: 'AUTHENTICATED',
           clearAuthData: expect.any(Function),
         },
       },
@@ -200,7 +200,7 @@ describe('useWristbandAuth', () => {
         contextValue: {
           isAuthenticated: false,
           isLoading: false,
-          authStatus: AuthStatus.UNAUTHENTICATED,
+          authStatus: 'UNAUTHENTICATED',
           authError: null,
           userId: '',
           tenantId: '',
@@ -214,7 +214,7 @@ describe('useWristbandAuth', () => {
           authError: null,
           isAuthenticated: false,
           isLoading: false,
-          authStatus: AuthStatus.UNAUTHENTICATED,
+          authStatus: 'UNAUTHENTICATED',
           clearAuthData: expect.any(Function),
         },
       },
@@ -233,12 +233,12 @@ describe('useWristbandAuth', () => {
   });
 
   it('should return authError when present in context', () => {
-    const mockError = new WristbandError(WristbandErrorCode.SESSION_FETCH_FAILED, 'Session failed');
+    const mockError = new WristbandError('SESSION_FETCH_FAILED', 'Session failed');
 
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: false,
       isLoading: false,
-      authStatus: AuthStatus.UNAUTHENTICATED,
+      authStatus: 'UNAUTHENTICATED',
       authError: mockError,
       userId: '',
       tenantId: '',
@@ -256,7 +256,7 @@ describe('useWristbandAuth', () => {
     const { result } = renderHook(() => useWristbandAuth(), { wrapper });
 
     expect(result.current.authError).toBe(mockError);
-    expect(result.current.authError?.code).toBe(WristbandErrorCode.SESSION_FETCH_FAILED);
+    expect(result.current.authError?.code).toBe('SESSION_FETCH_FAILED');
     expect(result.current.authError?.message).toBe('Session failed');
   });
 
@@ -264,7 +264,7 @@ describe('useWristbandAuth', () => {
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',
@@ -292,16 +292,16 @@ describe('useWristbandAuth', () => {
 
   it('should handle different types of authError', () => {
     const testCases = [
-      new WristbandError(WristbandErrorCode.INVALID_SESSION_RESPONSE, 'Invalid session'),
-      new WristbandError(WristbandErrorCode.TOKEN_FETCH_FAILED, 'Token failed'),
-      new WristbandError(WristbandErrorCode.UNAUTHENTICATED, 'Not authenticated'),
+      new WristbandError('INVALID_SESSION_RESPONSE', 'Invalid session'),
+      new WristbandError('TOKEN_FETCH_FAILED', 'Token failed'),
+      new WristbandError('UNAUTHENTICATED', 'Not authenticated'),
     ];
 
     testCases.forEach((error) => {
       const contextValue: IWristbandAuthContext = {
         isAuthenticated: false,
         isLoading: false,
-        authStatus: AuthStatus.UNAUTHENTICATED,
+        authStatus: 'UNAUTHENTICATED',
         authError: error,
         userId: '',
         tenantId: '',

--- a/test/hooks/use-wristband-session.test.tsx
+++ b/test/hooks/use-wristband-session.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, renderHook, act } from '@testing-library/react';
 
 import { useWristbandSession } from '../../src/hooks/use-wristband-session';
 import { WristbandAuthContext } from '../../src/context/wristband-auth-context';
-import { AuthStatus, IWristbandAuthContext } from '../../src/types/auth-provider-types';
+import { IWristbandAuthContext } from '../../src/types/auth-provider-types';
 
 // Type definition for a strongly-typed session example
 interface UserSessionData {
@@ -26,7 +26,7 @@ describe('useWristbandSession', () => {
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',
@@ -89,7 +89,7 @@ describe('useWristbandSession', () => {
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',
@@ -125,7 +125,7 @@ describe('useWristbandSession', () => {
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',
@@ -178,7 +178,7 @@ describe('useWristbandSession', () => {
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',
@@ -230,7 +230,7 @@ describe('useWristbandSession', () => {
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',

--- a/test/hooks/use-wristband-token.test.tsx
+++ b/test/hooks/use-wristband-token.test.tsx
@@ -5,7 +5,7 @@ import { fail } from 'assert';
 
 import { useWristbandToken } from '../../src/hooks/use-wristband-token';
 import { WristbandAuthContext } from '../../src/context/wristband-auth-context';
-import { AuthStatus, IWristbandAuthContext, WristbandErrorCode } from '../../src/types/auth-provider-types';
+import { IWristbandAuthContext } from '../../src/types/auth-provider-types';
 import { WristbandError } from '../../src/error';
 
 describe('useWristbandToken', () => {
@@ -21,7 +21,7 @@ describe('useWristbandToken', () => {
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',
@@ -54,7 +54,7 @@ describe('useWristbandToken', () => {
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',
@@ -83,15 +83,13 @@ describe('useWristbandToken', () => {
   });
 
   it('should throw WristbandError when user is not authenticated', async () => {
-    const mockGetToken = vi
-      .fn()
-      .mockRejectedValue(new WristbandError(WristbandErrorCode.UNAUTHENTICATED, 'User is not authenticated'));
+    const mockGetToken = vi.fn().mockRejectedValue(new WristbandError('UNAUTHENTICATED', 'User is not authenticated'));
     const mockClearToken = vi.fn();
 
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: false,
       isLoading: false,
-      authStatus: AuthStatus.UNAUTHENTICATED,
+      authStatus: 'UNAUTHENTICATED',
       authError: null,
       userId: '',
       tenantId: '',
@@ -125,15 +123,13 @@ describe('useWristbandToken', () => {
   });
 
   it('should throw WristbandError when tokenUrl is not configured', async () => {
-    const mockGetToken = vi
-      .fn()
-      .mockRejectedValue(new WristbandError(WristbandErrorCode.INVALID_TOKEN_URL, 'Token URL not configured'));
+    const mockGetToken = vi.fn().mockRejectedValue(new WristbandError('INVALID_TOKEN_URL', 'Token URL not configured'));
     const mockClearToken = vi.fn();
 
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',
@@ -170,18 +166,14 @@ describe('useWristbandToken', () => {
     const mockGetToken = vi
       .fn()
       .mockRejectedValue(
-        new WristbandError(
-          WristbandErrorCode.UNAUTHENTICATED,
-          'Token request unauthorized',
-          new Error('401 Unauthorized')
-        )
+        new WristbandError('UNAUTHENTICATED', 'Token request unauthorized', new Error('401 Unauthorized'))
       );
     const mockClearToken = vi.fn();
 
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',
@@ -217,15 +209,13 @@ describe('useWristbandToken', () => {
   it('should throw WristbandError for general token fetch failures', async () => {
     const mockGetToken = vi
       .fn()
-      .mockRejectedValue(
-        new WristbandError(WristbandErrorCode.TOKEN_FETCH_FAILED, 'Failed to fetch token', new Error('Network error'))
-      );
+      .mockRejectedValue(new WristbandError('TOKEN_FETCH_FAILED', 'Failed to fetch token', new Error('Network error')));
     const mockClearToken = vi.fn();
 
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',
@@ -266,7 +256,7 @@ describe('useWristbandToken', () => {
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',
@@ -301,7 +291,7 @@ describe('useWristbandToken', () => {
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',
@@ -343,7 +333,7 @@ describe('useWristbandToken', () => {
     const mockGetToken = vi
       .fn()
       .mockResolvedValueOnce('test-token-456')
-      .mockRejectedValueOnce(new WristbandError(WristbandErrorCode.UNAUTHENTICATED, 'User is not authenticated'));
+      .mockRejectedValueOnce(new WristbandError('UNAUTHENTICATED', 'User is not authenticated'));
     const mockClearToken = vi.fn();
 
     // Create a test component that uses the hook
@@ -390,7 +380,7 @@ describe('useWristbandToken', () => {
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
       isLoading: false,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       authError: null,
       userId: 'user-123',
       tenantId: 'tenant-456',

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -18,28 +18,6 @@ describe('Public API exports', () => {
     expect(typeof api.useWristbandSession).toBe('function');
   });
 
-  it('should export AuthStatus enum', () => {
-    expect(api.AuthStatus).toBeDefined();
-    expect(Object.keys(api.AuthStatus).length).toBe(3);
-    expect(api.AuthStatus.LOADING).toBe('LOADING');
-    expect(api.AuthStatus.AUTHENTICATED).toBe('AUTHENTICATED');
-    expect(api.AuthStatus.UNAUTHENTICATED).toBe('UNAUTHENTICATED');
-  });
-
-  it('should export WristbandErrorCode enum', () => {
-    expect(api.WristbandErrorCode).toBeDefined();
-    expect(Object.keys(api.WristbandErrorCode).length).toBe(9);
-    expect(api.WristbandErrorCode.INVALID_LOGIN_URL).toBe('INVALID_LOGIN_URL');
-    expect(api.WristbandErrorCode.INVALID_LOGOUT_URL).toBe('INVALID_LOGOUT_URL');
-    expect(api.WristbandErrorCode.INVALID_SESSION_RESPONSE).toBe('INVALID_SESSION_RESPONSE');
-    expect(api.WristbandErrorCode.INVALID_SESSION_URL).toBe('INVALID_SESSION_URL');
-    expect(api.WristbandErrorCode.INVALID_TOKEN_RESPONSE).toBe('INVALID_TOKEN_RESPONSE');
-    expect(api.WristbandErrorCode.INVALID_TOKEN_URL).toBe('INVALID_TOKEN_URL');
-    expect(api.WristbandErrorCode.SESSION_FETCH_FAILED).toBe('SESSION_FETCH_FAILED');
-    expect(api.WristbandErrorCode.TOKEN_FETCH_FAILED).toBe('TOKEN_FETCH_FAILED');
-    expect(api.WristbandErrorCode.UNAUTHENTICATED).toBe('UNAUTHENTICATED');
-  });
-
   it('should export utility functions', () => {
     expect(api.redirectToLogin).toBeDefined();
     expect(typeof api.redirectToLogin).toBe('function');
@@ -54,24 +32,25 @@ describe('Public API exports', () => {
       'useWristbandAuth',
       'useWristbandSession',
       'useWristbandToken',
-      'AuthStatus',
       'WristbandError',
-      'WristbandErrorCode',
+      'getCsrfToken',
       'redirectToLogin',
       'redirectToLogout',
     ];
 
     // Type-only exports (not testable at runtime):
+    // - AuthStatus
     // - SessionResponse
     // - LoginRedirectConfig
     // - LogoutRedirectConfig
+    // - WristbandErrorCode
 
     const actualExports = Object.keys(api);
-    expect(actualExports.length).toBe(9); // Runtime exports only
+    expect(actualExports.length).toBe(8); // Runtime exports only
 
-    // Total exports should be 12 (9 runtime + 3 types)
-    const totalExpectedExports = expectedRuntimeExports.length + 3; // +3 for type exports
-    expect(totalExpectedExports).toBe(12);
+    // Total exports should be 13 (8 runtime + 5 types)
+    const totalExpectedExports = expectedRuntimeExports.length + 5; // +4 for type exports
+    expect(totalExpectedExports).toBe(13);
 
     // Ensure all expected exports exist
     expectedRuntimeExports.forEach((exportName) => {

--- a/test/types/auth-provider-types.test.tsx
+++ b/test/types/auth-provider-types.test.tsx
@@ -1,26 +1,18 @@
 import { describe, it, expect } from 'vitest';
 
 import {
-  AuthStatus,
   IWristbandAuthContext,
   IWristbandAuthProviderProps,
   SessionResponse,
 } from '../../src/types/auth-provider-types';
 
 describe('Auth Provider Types', () => {
-  // Test AuthStatus enum values
-  it('should have the correct AuthStatus enum values', () => {
-    expect(AuthStatus.LOADING).toBe('LOADING');
-    expect(AuthStatus.AUTHENTICATED).toBe('AUTHENTICATED');
-    expect(AuthStatus.UNAUTHENTICATED).toBe('UNAUTHENTICATED');
-  });
-
   // Test that interfaces exist and can be used
   it('should allow creating objects that match the auth context interface', () => {
     // Create a valid context object
     const contextValue: IWristbandAuthContext = {
       authError: null,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       isAuthenticated: true,
       isLoading: false,
       metadata: {},
@@ -34,7 +26,7 @@ describe('Auth Provider Types', () => {
 
     expect(contextValue).toBeDefined();
     expect(contextValue.authError).toBeNull();
-    expect(contextValue.authStatus).toBe(AuthStatus.AUTHENTICATED);
+    expect(contextValue.authStatus).toBe('AUTHENTICATED');
     expect(contextValue.isAuthenticated).toBe(true);
     expect(contextValue.isLoading).toBe(false);
     expect(contextValue.tenantId).toBe('tenant-123');
@@ -96,7 +88,7 @@ describe('Auth Provider Types', () => {
 
     const typedContext: IWristbandAuthContext<UserMetadata> = {
       authError: null,
-      authStatus: AuthStatus.AUTHENTICATED,
+      authStatus: 'AUTHENTICATED',
       isAuthenticated: true,
       isLoading: false,
       metadata: { name: 'Test User', role: 'admin' },

--- a/test/types/util-types.test.ts
+++ b/test/types/util-types.test.ts
@@ -20,13 +20,13 @@ describe('Utility Types', () => {
     const fullConfig: LoginRedirectConfig = {
       loginHint: 'admin@example.com',
       returnUrl: '/admin-dashboard',
-      tenantDomain: 'acme-corp',
+      tenantName: 'acme-corp',
       tenantCustomDomain: 'auth.acme.com',
     };
 
     expect(fullConfig.loginHint).toBe('admin@example.com');
     expect(fullConfig.returnUrl).toBe('/admin-dashboard');
-    expect(fullConfig.tenantDomain).toBe('acme-corp');
+    expect(fullConfig.tenantName).toBe('acme-corp');
     expect(fullConfig.tenantCustomDomain).toBe('auth.acme.com');
   });
 
@@ -35,11 +35,11 @@ describe('Utility Types', () => {
     const emptyConfig: LogoutRedirectConfig = {};
     expect(emptyConfig).toBeDefined();
 
-    // Partial config with tenantDomain only
+    // Partial config with tenantName only
     const domainOnlyConfig: LogoutRedirectConfig = {
-      tenantDomain: 'acme-corp',
+      tenantName: 'acme-corp',
     };
-    expect(domainOnlyConfig.tenantDomain).toBe('acme-corp');
+    expect(domainOnlyConfig.tenantName).toBe('acme-corp');
     expect(domainOnlyConfig.tenantCustomDomain).toBeUndefined();
 
     // Partial config with tenantCustomDomain only
@@ -47,15 +47,15 @@ describe('Utility Types', () => {
       tenantCustomDomain: 'auth.acme.com',
     };
     expect(customDomainOnlyConfig.tenantCustomDomain).toBe('auth.acme.com');
-    expect(customDomainOnlyConfig.tenantDomain).toBeUndefined();
+    expect(customDomainOnlyConfig.tenantName).toBeUndefined();
 
     // Complete config with all properties
     const fullConfig: LogoutRedirectConfig = {
-      tenantDomain: 'acme-corp',
+      tenantName: 'acme-corp',
       tenantCustomDomain: 'auth.acme.com',
     };
 
-    expect(fullConfig.tenantDomain).toBe('acme-corp');
+    expect(fullConfig.tenantName).toBe('acme-corp');
     expect(fullConfig.tenantCustomDomain).toBe('auth.acme.com');
   });
 
@@ -63,23 +63,23 @@ describe('Utility Types', () => {
     const config: LoginRedirectConfig = {
       loginHint: 'user@example.com',
       returnUrl: '/dashboard',
-      tenantDomain: 'acme-corp',
+      tenantName: 'acme-corp',
       tenantCustomDomain: 'auth.acme.com',
     };
 
     expect(typeof config.loginHint).toBe('string');
     expect(typeof config.returnUrl).toBe('string');
-    expect(typeof config.tenantDomain).toBe('string');
+    expect(typeof config.tenantName).toBe('string');
     expect(typeof config.tenantCustomDomain).toBe('string');
   });
 
   it('should enforce property types for LogoutRedirectConfig', () => {
     const config: LogoutRedirectConfig = {
-      tenantDomain: 'acme-corp',
+      tenantName: 'acme-corp',
       tenantCustomDomain: 'auth.acme.com',
     };
 
-    expect(typeof config.tenantDomain).toBe('string');
+    expect(typeof config.tenantName).toBe('string');
     expect(typeof config.tenantCustomDomain).toBe('string');
   });
 });

--- a/test/utils/auth-utils.test.ts
+++ b/test/utils/auth-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
-import { redirectToLogin, redirectToLogout } from '../../src/utils/auth-utils';
+import { getCsrfToken, redirectToLogin, redirectToLogout } from '../../src/utils/auth-utils';
 import { WristbandError } from '../../src/error';
 
 describe('Auth utilities', () => {
@@ -66,9 +66,9 @@ describe('Auth utilities', () => {
         'loginUrl must not include reserved query param: "return_url"'
       );
 
-      expect(() => redirectToLogin('/api/auth/login?tenant_domain=example')).toThrow();
-      expect(() => redirectToLogin('/api/auth/login?tenant_domain=example')).toThrow(
-        'loginUrl must not include reserved query param: "tenant_domain"'
+      expect(() => redirectToLogin('/api/auth/login?tenant_name=example')).toThrow();
+      expect(() => redirectToLogin('/api/auth/login?tenant_name=example')).toThrow(
+        'loginUrl must not include reserved query param: "tenant_name"'
       );
 
       expect(() => redirectToLogin('/api/auth/login?tenant_custom_domain=example.com')).toThrow();
@@ -83,7 +83,7 @@ describe('Auth utilities', () => {
       expect(url).toContain('https://auth.example.com/login');
       expect(url).not.toContain('return_url=');
       expect(url).not.toContain('login_hint=');
-      expect(url).not.toContain('tenant_domain=');
+      expect(url).not.toContain('tenant_name=');
       expect(url).not.toContain('tenant_custom_domain=');
     });
 
@@ -93,7 +93,7 @@ describe('Auth utilities', () => {
       expect(url).toContain('theme=dark');
       expect(url).not.toContain('return_url=');
       expect(url).not.toContain('login_hint=');
-      expect(url).not.toContain('tenant_domain=');
+      expect(url).not.toContain('tenant_name=');
       expect(url).not.toContain('tenant_custom_domain=');
     });
 
@@ -103,7 +103,7 @@ describe('Auth utilities', () => {
       expect(url).toContain('/api/auth/login');
       expect(url).toContain('return_url=https%3A%2F%2Fapp.example.com%2Fdashboard');
       expect(url).not.toContain('login_hint=');
-      expect(url).not.toContain('tenant_domain=');
+      expect(url).not.toContain('tenant_name=');
       expect(url).not.toContain('tenant_custom_domain=');
     });
 
@@ -113,15 +113,15 @@ describe('Auth utilities', () => {
       expect(url).toContain('/api/auth/login');
       expect(url).toContain('login_hint=user%40example.com');
       expect(url).not.toContain('return_url=');
-      expect(url).not.toContain('tenant_domain=');
+      expect(url).not.toContain('tenant_name=');
       expect(url).not.toContain('tenant_custom_domain=');
     });
 
-    it('should include tenant domain if provided', async () => {
-      redirectToLogin('/api/auth/login', { tenantDomain: 'acme-corp' });
+    it('should include tenant name if provided', async () => {
+      redirectToLogin('/api/auth/login', { tenantName: 'acme-corp' });
       const url = window.location.href;
       expect(url).toContain('/api/auth/login');
-      expect(url).toContain('tenant_domain=acme-corp');
+      expect(url).toContain('tenant_name=acme-corp');
       expect(url).not.toContain('return_url=');
       expect(url).not.toContain('login_hint=');
       expect(url).not.toContain('tenant_custom_domain=');
@@ -134,14 +134,14 @@ describe('Auth utilities', () => {
       expect(url).toContain('tenant_custom_domain=auth.acme.com');
       expect(url).not.toContain('return_url=');
       expect(url).not.toContain('login_hint=');
-      expect(url).not.toContain('tenant_domain=');
+      expect(url).not.toContain('tenant_name=');
     });
 
     it('should include all parameters if provided', async () => {
       redirectToLogin('/api/auth/login', {
         loginHint: 'user@example.com',
         returnUrl: 'https://app.example.com/dashboard',
-        tenantDomain: 'acme-corp',
+        tenantName: 'acme-corp',
         tenantCustomDomain: 'auth.acme.com',
       });
 
@@ -150,8 +150,21 @@ describe('Auth utilities', () => {
       expect(url).toContain('/api/auth/login?');
       expect(url).toContain('login_hint=user%40example.com');
       expect(url).toContain('return_url=https%3A%2F%2Fapp.example.com%2Fdashboard');
-      expect(url).toContain('tenant_domain=acme-corp');
+      expect(url).toContain('tenant_name=acme-corp');
       expect(url).toContain('tenant_custom_domain=auth.acme.com');
+    });
+
+    it('should return early when running server-side (no window)', () => {
+      // Mock server-side environment
+      const originalWindow = global.window;
+      // @ts-expect-error - Intentionally setting window to undefined for SSR test
+      delete global.window;
+
+      // Should not throw, just return early
+      expect(() => redirectToLogin('/api/auth/login')).not.toThrow();
+
+      // Restore window
+      global.window = originalWindow;
     });
   });
 
@@ -171,9 +184,9 @@ describe('Auth utilities', () => {
     });
 
     it('should throw if logoutUrl contains reserved query parameters', () => {
-      expect(() => redirectToLogout('/api/auth/logout?tenant_domain=example')).toThrow();
-      expect(() => redirectToLogout('/api/auth/logout?tenant_domain=example')).toThrow(
-        'logoutUrl must not include reserved query param: "tenant_domain"'
+      expect(() => redirectToLogout('/api/auth/logout?tenant_name=example')).toThrow();
+      expect(() => redirectToLogout('/api/auth/logout?tenant_name=example')).toThrow(
+        'logoutUrl must not include reserved query param: "tenant_name"'
       );
 
       expect(() => redirectToLogout('/api/auth/logout?tenant_custom_domain=example.com')).toThrow();
@@ -206,11 +219,11 @@ describe('Auth utilities', () => {
       }
     });
 
-    it('should include tenant domain if provided', async () => {
-      redirectToLogout('/api/auth/logout', { tenantDomain: 'acme-corp' });
+    it('should include tenant name if provided', async () => {
+      redirectToLogout('/api/auth/logout', { tenantName: 'acme-corp' });
       const url = window.location.href;
       expect(url).toContain('/api/auth/logout');
-      expect(url).toContain('tenant_domain=acme-corp');
+      expect(url).toContain('tenant_name=acme-corp');
     });
 
     it('should include tenant custom domain if provided', async () => {
@@ -222,14 +235,118 @@ describe('Auth utilities', () => {
 
     it('should include all parameters if provided', async () => {
       redirectToLogout('/api/auth/logout', {
-        tenantDomain: 'acme-corp',
+        tenantName: 'acme-corp',
         tenantCustomDomain: 'auth.acme.com',
       });
 
       const url = window.location.href;
       expect(url).toContain('/api/auth/logout?');
-      expect(url).toContain('tenant_domain=acme-corp');
+      expect(url).toContain('tenant_name=acme-corp');
       expect(url).toContain('tenant_custom_domain=auth.acme.com');
+    });
+
+    it('should return early when running server-side (no window)', () => {
+      // Mock server-side environment
+      const originalWindow = global.window;
+      // @ts-expect-error - Intentionally setting window to undefined for SSR test
+      delete global.window;
+
+      // Should not throw, just return early
+      expect(() => redirectToLogout('/api/auth/logout')).not.toThrow();
+
+      // Restore window
+      global.window = originalWindow;
+    });
+  });
+
+  describe('getCsrfToken', () => {
+    let originalCookie: string;
+
+    beforeEach(() => {
+      // Store original cookie
+      originalCookie = document.cookie;
+      // Clear all cookies
+      document.cookie.split(';').forEach((c) => {
+        document.cookie = c.replace(/^ +/, '').replace(/=.*/, `=;expires=${new Date().toUTCString()};path=/`);
+      });
+    });
+
+    afterEach(() => {
+      // Restore original cookie
+      document.cookie = originalCookie;
+    });
+
+    it('should return undefined if cookie is not found', () => {
+      const token = getCsrfToken();
+      expect(token).toBeUndefined();
+    });
+
+    it('should return the CSRF token from the default cookie name', () => {
+      document.cookie = 'CSRF-TOKEN=test-token-123';
+      const token = getCsrfToken();
+      expect(token).toBe('test-token-123');
+    });
+
+    it('should return the CSRF token from a custom cookie name', () => {
+      document.cookie = 'CUSTOM-CSRF=custom-token-456';
+      const token = getCsrfToken('CUSTOM-CSRF');
+      expect(token).toBe('custom-token-456');
+    });
+
+    it('should decode URI-encoded cookie values', () => {
+      document.cookie = 'CSRF-TOKEN=token%20with%20spaces';
+      const token = getCsrfToken();
+      expect(token).toBe('token with spaces');
+    });
+
+    it('should handle cookies with special characters', () => {
+      const specialToken = 'token+with/special=chars';
+      document.cookie = `CSRF-TOKEN=${encodeURIComponent(specialToken)}`;
+      const token = getCsrfToken();
+      expect(token).toBe(specialToken);
+    });
+
+    it('should return undefined for non-existent custom cookie name', () => {
+      document.cookie = 'CSRF-TOKEN=test-token-123';
+      const token = getCsrfToken('NON-EXISTENT');
+      expect(token).toBeUndefined();
+    });
+
+    it('should handle multiple cookies and find the correct one', () => {
+      document.cookie = 'session=abc123';
+      document.cookie = 'CSRF-TOKEN=my-csrf-token';
+      document.cookie = 'user=john';
+
+      const token = getCsrfToken();
+      expect(token).toBe('my-csrf-token');
+    });
+
+    it('should return undefined when running server-side (no window)', () => {
+      // Mock server-side environment
+      const originalWindow = global.window;
+      // @ts-expect-error - Intentionally setting window to undefined for SSR test
+      delete global.window;
+
+      const token = getCsrfToken();
+      expect(token).toBeUndefined();
+
+      // Restore window
+      global.window = originalWindow;
+    });
+
+    it('should handle empty cookie value', () => {
+      document.cookie = 'CSRF-TOKEN=';
+      const token = getCsrfToken();
+      expect(token).toBe('');
+    });
+
+    it('should match exact cookie name and not partial matches', () => {
+      document.cookie = 'PREFIX-CSRF-TOKEN=wrong-token';
+      document.cookie = 'CSRF-TOKEN=correct-token';
+      document.cookie = 'CSRF-TOKEN-SUFFIX=wrong-token-2';
+
+      const token = getCsrfToken();
+      expect(token).toBe('correct-token');
     });
   });
 });


### PR DESCRIPTION
## React Client Auth SDK v3.0.0

### Breaking Changes

**1. Tenant Domain → Tenant Name**

- `redirectToLogin()` and `redirectToLogout()` now use `tenantName` config instead of `tenantDomain`
- Query parameter changed from `tenant_domain` to `tenant_name`
- Backwards compatible: Pass `tenant_domain` in URL if backend doesn't support new naming yet

**2. Enums → String Literal Unions**

- `AuthStatus` and `WristbandErrorCode` are now string literal unions (not enums)
- Use `'LOADING'` instead of `AuthStatus.LOADING`
- Use `'UNAUTHENTICATED'` instead of `WristbandErrorCode.UNAUTHENTICATED`
- Benefits: Zero runtime overhead, better tree-shaking, simpler usage

### New Features

- Added `getCsrfToken()` utility for Fetch API users