### PR TITLE
Release 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ The SDK handles authentication interactions in your app’s React frontend. It�
   - [2) Use Auth and Session Hooks](#2-use-auth-and-session-hooks)
   - [3) Use Token Hook (Optional)](#3-use-token-hook-optional)
   - [4) Use Auth Utility Functions](#4-use-auth-utility-functions)
+- [Typed Session Metadata](#typed-session-metadata)
 - [Transforming Session Metadata](#transforming-session-metadata)
 - [Executing Custom Logic After Session Initialization](#executing-custom-logic-after-session-initialization)
+- [Revalidating the Session](#revalidating-the-session)
+- [Clearing Authentication Data](#clearing-authentication-data)
 - [API Reference](#api-reference)
   - [WristbandAuthProvider](#wristbandauthprovidertsessionmetadata)
   - [Hooks](#hooks)
@@ -167,6 +170,7 @@ This hook provides authentication status information and functionality:
 - `authError`: WristbandError object containing error details when authentication fails, or `null` when no error has occurred.
 - `authStatus`: String literal value for convenience (`LOADING`, `AUTHENTICATED`, or `UNAUTHENTICATED`).
 - `clearAuthData()`: Function that destroys all auth, session, and token data (auth status becomes `UNAUTHENTICATED`).
+- `validateSession()`: Async function that re-fetches the session from your backend and updates auth state. Useful in scenarios where authentication state may have changed without a full page reload, such as after completing an auth flow in a popup window or recovering from an unauthenticated state when `disableRedirectOnUnauthenticated` is `true`.
 
 Use this hook when you need to control access to protected content by checking authentication status.  This enables common patterns like conditional rendering of authenticated/unauthenticated views, route protection, or dynamic UI updates based on the user's auth status.
 
@@ -174,7 +178,7 @@ Use this hook when you need to control access to protected content by checking a
 import { useWristbandAuth } from '@wristband/react-client-auth';
 
 function AuthStatus() {
-  const { authError, isAuthenticated, isLoading, authStatus, clearAuthData } = useWristbandAuth();
+  const { authError, isAuthenticated, isLoading, authStatus } = useWristbandAuth();
   
   if (isLoading) {
     return <div>Checking authentication status...</div>;
@@ -194,30 +198,6 @@ function AuthStatus() {
           <p>Error message: {authError.message}</p>
         </>
       )}
-    </div>
-  );
-}
-```
-
-The `clearAuthData()` function permanently clears all client-side auth state, session data, and token data. You can optionally use this when you need to completely reset the SDK state, typically for testing, error recovery, or when implementing custom logout flows. Note that this only clears React state and does not invalidate session cookies nor redirect the user. For standard logout, redirect to your server's Logout Endpoint instead.
-
-```typescript
-import { redirectToLogin, useWristbandAuth } from '@wristband/react-client-auth';
-
-function ClearAuth() {
-  const { clearAuthData } = useWristbandAuth();
-  
-  const reauthenticate = () => {
-    clearAuthData();
-    redirectToLogin('https://your-server.com/api/auth/login');
-  };
-  
-  return (
-    <div>
-      <h2>Clear Authentication Data</h2>
-      <button onClick={() => reauthenticate()}>
-        Re-Authenticate
-      </button>
     </div>
   );
 }
@@ -263,45 +243,6 @@ function UserProfile() {
 }
 ```
 
-For TypeScript applications, you can leverage type safety when working with session metadata. By providing a type parameter to the `useWristbandSession` hook, you can ensure that your metadata object and update functions are properly typed. This approach ensures proper IDE autocomplete suggestions for metadata properties as well as compile-time type checking for the values you pass to `updateMetadata`.
-
-```typescript
-import { useWristbandSession } from '@wristband/react-client-auth';
-
-interface UserPreferences {
-  theme: 'light' | 'dark';
-  notifications: boolean;
-  language: string;
-}
-
-function PreferencesPanel() {
-  const { metadata, updateMetadata } = useWristbandSession<UserPreferences>();
-  
-  const toggleTheme = () => {
-    const newTheme = metadata.theme === 'light' ? 'dark' : 'light';
-    updateMetadata({ theme: newTheme });
-  };
-  
-  return (
-    <div>
-      <h2>Your Preferences</h2>
-      <button onClick={toggleTheme}>
-        Switch to {metadata.theme === 'light' ? 'Dark' : 'Light'} Mode
-      </button>
-      
-      <label>
-        <input 
-          type="checkbox"
-          checked={metadata.notifications}
-          onChange={(e) => updateMetadata({ notifications: e.target.checked })}
-        />
-        Enable Notifications
-      </label>
-    </div>
-  );
-}
-```
-
 ### 3) Use Token Hook (Optional)
 
 When following Wristband’s backend server integration pattern, the recommended approach is to protect your backend APIs by relying solely on the session cookie, which the browser automatically includes with each request. Your backend should use middleware to validate the session, verify the CSRF token, and refresh expired tokens if necessary. This is the most secure way to protect your backend.
@@ -313,7 +254,7 @@ Alternatively, the React SDK can extract the access token from the authenticated
 The useWristbandToken() hook exposes functionality for managing access tokens in the browser:
 
 - `getToken()`: Retrieves a valid access token for making authenticated API calls to resource servers. Returns a cached token if available and not expired, otherwise fetches a fresh token from the configured `tokenUrl` endpoint. The access token does not persist across page navigations or refreshes. Your server's Token Endpoint is responsible for refreshing expired tokens by using the user's session state.
-- `clearToken()`: Function to modify the metadata object stored in the client-side React Context. This enables real-time UI updates with new metadata values, but it is limited to the current browser session only. Any changes made with this function will not persist across page refreshes or be synchronized to your backend server.
+- `clearToken()`: Clears the cached access token and forces the next getToken() call to fetch a fresh token, assuming that the user still has a valid session cookie.
 
 In order to use this hook, you must first configure the `tokenUrl` property on the `WristbandAuthProvider` to point to your server's Token Endpoint:
 
@@ -426,6 +367,49 @@ export function ExampleApiComponent() {
     <button onClick={executeServerApiCall}>
       Get Resource
     </button>
+  );
+}
+```
+
+<br>
+
+## Typed Session Metadata
+
+For TypeScript applications, you can leverage type safety when working with session metadata. By providing a type parameter to the `useWristbandSession` hook, you can ensure that your metadata object and update functions are properly typed. This approach ensures proper IDE autocomplete suggestions for metadata properties as well as compile-time type checking for the values you pass to `updateMetadata`.
+
+```typescript
+import { useWristbandSession } from '@wristband/react-client-auth';
+ 
+interface UserPreferences {
+  theme: 'light' | 'dark';
+  notifications: boolean;
+  language: string;
+}
+ 
+function PreferencesPanel() {
+  const { metadata, updateMetadata } = useWristbandSession<UserPreferences>();
+  
+  const toggleTheme = () => {
+    const newTheme = metadata.theme === 'light' ? 'dark' : 'light';
+    updateMetadata({ theme: newTheme });
+  };
+  
+  return (
+    <div>
+      <h2>Your Preferences</h2>
+      <button onClick={toggleTheme}>
+        Switch to {metadata.theme === 'light' ? 'Dark' : 'Light'} Mode
+      </button>
+      
+      <label>
+        <input 
+          type="checkbox"
+          checked={metadata.notifications}
+          onChange={(e) => updateMetadata({ notifications: e.target.checked })}
+        />
+        Enable Notifications
+      </label>
+    </div>
   );
 }
 ```
@@ -566,6 +550,105 @@ function App() {
 
 <br>
 
+## Revalidating the Session
+
+In some authentication flows, the user completes login in a separate context (such as a popup window) without triggering a full page reload in the main application. In these cases, the `WristbandAuthProvider` won't automatically detect that the user is now authenticated because it only fetches the session on initial mount.
+
+The `validateSession()` function from `useWristbandAuth()` solves this by allowing you to manually re-fetch the session and update the auth state at any point after the provider has mounted.
+
+### Popup Login Example
+
+A common pattern is to open a popup window that completes the OAuth flow, then use `postMessage` to notify the parent window when authentication is successful. The parent window can then call `validateSession()` to refresh its auth state and navigate to the protected page.
+
+```typescript
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useWristbandAuth } from '@wristband/react-client-auth';
+
+function LoginPage() {
+  const { validateSession } = useWristbandAuth();
+  const navigate = useNavigate();
+
+  const handleLoginSuccess = useCallback(async () => {
+    // Re-fetch session after popup login completes
+    await validateSession();
+    navigate('/dashboard');
+  }, [validateSession, navigate]);
+
+  const openLoginPopup = () => {
+    const popup = window.open('/api/auth/login-with-popup', 'login-popup', 'width=500,height=650');
+
+    window.addEventListener('message', async (event) => {
+      if (event.origin !== window.location.origin || event.data?.type !== 'login_success') {
+        return;
+      }
+      popup?.close();
+      await handleLoginSuccess();
+    }, { once: true });
+  };
+
+  return (
+    <button onClick={openLoginPopup}>
+      Log in with Google
+    </button>
+  );
+}
+```
+
+### Re-Authenticating After an Unauthenticated State
+
+If your app uses `disableRedirectOnUnauthenticated={true}`, you may have pages that serve both authenticated and unauthenticated users. In these cases, you can call `validateSession()` at any point to check whether the user has since authenticated (e.g., after they complete a login flow inline on the page).
+
+```typescript
+import { useWristbandAuth } from '@wristband/react-client-auth';
+
+function PublicPage() {
+  const { isAuthenticated, validateSession } = useWristbandAuth();
+
+  return (
+    <div>
+      {isAuthenticated ? (
+        <p>Welcome back!</p>
+      ) : (
+        <button onClick={() => validateSession()}>
+          Check if I'm logged in
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+<br>
+
+## Clearing Authentication Data
+
+The `clearAuthData()` function from `useWristbandAuth()` permanently clears all client-side auth state, session data, and token data. You can optionally use this when you need to completely reset the SDK state, typically for testing, error recovery, or when implementing custom logout flows. Note that this only clears React state and does not invalidate session cookies nor redirect the user. For standard logout, redirect to your server's Logout Endpoint instead.
+ 
+```typescript
+import { redirectToLogin, useWristbandAuth } from '@wristband/react-client-auth';
+ 
+function ClearAuth() {
+  const { clearAuthData } = useWristbandAuth();
+  
+  const reauthenticate = () => {
+    clearAuthData();
+    redirectToLogin('https://your-server.com/api/auth/login');
+  };
+  
+  return (
+    <div>
+      <h2>Clear Authentication Data</h2>
+      <button onClick={() => reauthenticate()}>
+        Re-Authenticate
+      </button>
+    </div>
+  );
+}
+```
+
+<br>
+
 ## API Reference
 
 ### `<WristbandAuthProvider<TSessionMetadata>>`
@@ -626,7 +709,7 @@ export default function App() {
 import { useWristbandAuth } from '@wristband/react-client-auth';
 
 function AuthHook() {
-  const { authError, authStatus, clearAuthData, isAuthenticated, isLoading } = useWristbandAuth();
+  const { authError, authStatus, clearAuthData, isAuthenticated, isLoading, validateSession } = useWristbandAuth();
   
   return (
     <div>
@@ -636,6 +719,9 @@ function AuthHook() {
       <p>isLoading: {isLoading}</p>
       <button onClick={() => clearAuthData()}>
         Clear Auth Data
+      </button>
+      <button onClick={() => validateSession()}>
+        Validate Session
       </button>
     </div>
   );
@@ -649,6 +735,7 @@ function AuthHook() {
 | clearAuthData | `() => void` | This function clears all client-side auth state including authentication status, user data, session metadata, cached tokens, and errors. |
 | isAuthenticated | boolean | A boolean indicator that is `true` when the user is authenticated and `false` otherwise. |
 | isLoading | boolean | A boolean indicator that is `true` when the authentication status is still being determined (e.g., during the initial session check) and `false` once the status is determined. |
+| validateSession | `() => Promise<void>` | Re-fetches the session from your backend's Session Endpoint and updates auth state. Sets `isLoading` to `true` during the request. On success, updates `userId`, `tenantId`, `metadata`, and sets `isAuthenticated` to `true`. On failure, either redirects to the login URL or sets `authError` and `isAuthenticated` to `false` depending on the value of `disableRedirectOnUnauthenticated`. |
 
 In the event an `authError` occurs, the `WristbandError` can have any of the following error codes:
 
@@ -726,7 +813,7 @@ function TokenHook() {
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | clearToken | `() => void` | Clears the cached access token and forces the next getToken() call to fetch a fresh token, assuming that the user still has a valid session cookie. |
-| getToken | `() => void` | Retrieves a valid access token for making authenticated API calls to resource servers. Returns a cached token if available and not expired; otherwise fetches a fresh token from the configured "tokenUrl" endpoint. Your server's Token Endpoint should automatically handle token expiration and refresh using the user's session cookie. |
+| getToken | `() => Promise<string>` | Retrieves a valid access token for making authenticated API calls to resource servers. Returns a cached token if available and not expired; otherwise fetches a fresh token from the configured "tokenUrl" endpoint. Your server's Token Endpoint should automatically handle token expiration and refresh using the user's session cookie. |
 
 <br>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wristband/react-client-auth",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wristband/react-client-auth",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
@@ -6112,9 +6112,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A lightweight React SDK that pairs with your backend server auth to initialize and sync frontend sessions via secure session cookies.",
   "author": "Wristband",
   "homepage": "https://wristband.dev",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "license": "MIT",
   "sideEffects": false,
   "type": "module",

--- a/src/context/wristband-auth-provider.tsx
+++ b/src/context/wristband-auth-provider.tsx
@@ -80,7 +80,8 @@ const API_RETRY_DELAY_MS = 100;
  * ```
  *
  * Once rendered, child components can access authentication state using the hooks:
- * - useWristbandAuth() - For authentication status (isAuthenticated, isLoading, authStatus, clearAuthData)
+ * - useWristbandAuth() - For authentication status (isAuthenticated, isLoading, authStatus, clearAuthData,
+ *   validateSession)
  * - useWristbandSession() - For session data (userId, tenantId, metadata)
  * - useWristbandToken() - For client-side token management, if applicable (getToken, clearToken)
  *
@@ -140,7 +141,7 @@ export function WristbandAuthProvider<TSessionMetaData = unknown>({
   }, []);
 
   /**
-   * Allows setting of session metadata even after initial fetchSession() occurs.
+   * Allows setting of session metadata even after initial validateSession() occurs.
    */
   const updateMetadata = useCallback((newMetadata: Partial<TSessionMetaData>) => {
     setMetadata((prevData) => ({ ...prevData, ...newMetadata }));
@@ -249,94 +250,123 @@ export function WristbandAuthProvider<TSessionMetaData = unknown>({
   }, [isAuthenticated, accessToken, accessTokenExpiresAt]);
 
   /**
+   * Re-validates the authenticated user's session by re-fetching from the session endpoint
+   * and updating auth state. Called automatically on mount to bootstrap the application,
+   * and can be called manually in scenarios where authentication state may have changed
+   * without a full page reload, such as after completing an auth flow in a popup window
+   * or recovering from an unauthenticated state when `disableRedirectOnUnauthenticated` is `true`.
+   *
+   * On success, updates userId, tenantId, metadata, and sets isAuthenticated to true.
+   * On failure, either redirects to the login URL or sets authError and isAuthenticated to false
+   * depending on the value of `disableRedirectOnUnauthenticated`.
+   *
+   * @returns Promise that resolves when session validation is complete
+   * @throws {WristbandError} with code `INVALID_SESSION_RESPONSE` if the session endpoint
+   *   response is missing required fields (dev configuration error — not retried)
+   * @throws {WristbandError} with code `UNAUTHENTICATED` if the session endpoint returns 401
+   * @throws {WristbandError} with code `SESSION_FETCH_FAILED` if the session endpoint returns
+   *   a non-401 error after all retry attempts are exhausted
+   *
+   * @example
+   * ```typescript
+   * const { validateSession } = useWristbandAuth();
+   *
+   * const handleLoginSuccess = async () => {
+   *   await validateSession();
+   *   navigate('/dashboard');
+   * };
+   * ```
+   */
+  const validateSession = useCallback(async () => {
+    setIsLoading(true);
+    let lastError: WristbandError | null = null;
+
+    for (let attempt = 1; attempt <= MAX_API_ATTEMPTS; attempt++) {
+      try {
+        // The session API will let React know if the user has a previously authenticated session.
+        // If so, it will initialize session data.
+        const response = await apiClient.get<SessionResponse>(validatedSessionUrl, {
+          csrfCookieName,
+          csrfHeaderName,
+        });
+        const { userId, tenantId, metadata: rawMetadata } = response.data;
+
+        if (!userId || !userId.trim()) {
+          throw new WristbandError(
+            'INVALID_SESSION_RESPONSE',
+            'Session Endpoint response is missing required field: "userId"'
+          );
+        }
+
+        if (!tenantId || !tenantId.trim()) {
+          throw new WristbandError(
+            'INVALID_SESSION_RESPONSE',
+            'Session Endpoint response is missing required field: "tenantId"'
+          );
+        }
+
+        // Execute side effects callback before updating state if provided
+        if (onSessionSuccess) {
+          await Promise.resolve(onSessionSuccess(response.data));
+        }
+
+        // Apply transformation if provided
+        if (rawMetadata) {
+          setMetadata(
+            transformSessionMetadata ? transformSessionMetadata(rawMetadata) : (rawMetadata as TSessionMetaData)
+          );
+        }
+
+        // Update remaining context state last
+        setTenantId(tenantId);
+        setUserId(userId);
+        setIsAuthenticated(true);
+        setIsLoading(false);
+        setAuthError(null);
+        return;
+      } catch (error) {
+        // Always bubble up invalid response errors (represents a dev configuration error)
+        if (error instanceof WristbandError) {
+          throw error;
+        }
+
+        if (isUnauthorizedError(error)) {
+          lastError = new WristbandError('UNAUTHENTICATED', 'User is not authenticated', error);
+          break;
+        }
+
+        // If it's a non-401 4xx error, bail early (don't retry client errors)
+        if (is4xxError(error)) {
+          lastError = new WristbandError('SESSION_FETCH_FAILED', 'Failed to fetch session', error);
+          break;
+        }
+
+        // If this is the last attempt, don't delay
+        if (attempt === MAX_API_ATTEMPTS) {
+          lastError = new WristbandError('SESSION_FETCH_FAILED', 'Failed to fetch session', error);
+          break;
+        }
+
+        // Wait before retrying (only for 5xx errors and network issues)
+        await delay(API_RETRY_DELAY_MS);
+      }
+    }
+
+    if (disableRedirectOnUnauthenticated) {
+      setAuthError(lastError);
+      setIsAuthenticated(false);
+      setIsLoading(false);
+    } else {
+      // Preserve the current page for when the user returns after re-authentication.
+      window.location.href = resolvedLoginUrl;
+    }
+  }, []);
+
+  /**
    * Bootstrap the application with the authenticated user's session data via session cookie.
    */
   useEffect(() => {
-    const fetchSession = async () => {
-      let lastError: WristbandError | null = null;
-
-      for (let attempt = 1; attempt <= MAX_API_ATTEMPTS; attempt++) {
-        try {
-          // The session API will let React know if the user has a previously authenticated session.
-          // If so, it will initialize session data.
-          const response = await apiClient.get<SessionResponse>(validatedSessionUrl, {
-            csrfCookieName,
-            csrfHeaderName,
-          });
-          const { userId, tenantId, metadata: rawMetadata } = response.data;
-
-          if (!userId || !userId.trim()) {
-            throw new WristbandError(
-              'INVALID_SESSION_RESPONSE',
-              'Session Endpoint response is missing required field: "userId"'
-            );
-          }
-
-          if (!tenantId || !tenantId.trim()) {
-            throw new WristbandError(
-              'INVALID_SESSION_RESPONSE',
-              'Session Endpoint response is missing required field: "tenantId"'
-            );
-          }
-
-          // Execute side effects callback before updating state if provided
-          if (onSessionSuccess) {
-            await Promise.resolve(onSessionSuccess(response.data));
-          }
-
-          // Apply transformation if provided
-          if (rawMetadata) {
-            setMetadata(
-              transformSessionMetadata ? transformSessionMetadata(rawMetadata) : (rawMetadata as TSessionMetaData)
-            );
-          }
-
-          // Update remaining context state last
-          setTenantId(tenantId);
-          setUserId(userId);
-          setIsAuthenticated(true);
-          setIsLoading(false);
-          setAuthError(null);
-          return;
-        } catch (error) {
-          // Always bubble up invalid response errors (represents a dev configuration error)
-          if (error instanceof WristbandError) {
-            throw error;
-          }
-
-          if (isUnauthorizedError(error)) {
-            lastError = new WristbandError('UNAUTHENTICATED', 'User is not authenticated', error);
-            break;
-          }
-
-          // If it's a non-401 4xx error, bail early (don't retry client errors)
-          if (is4xxError(error)) {
-            lastError = new WristbandError('SESSION_FETCH_FAILED', 'Failed to fetch session', error);
-            break;
-          }
-
-          // If this is the last attempt, don't delay
-          if (attempt === MAX_API_ATTEMPTS) {
-            lastError = new WristbandError('SESSION_FETCH_FAILED', 'Failed to fetch session', error);
-            break;
-          }
-
-          // Wait before retrying (only for 5xx errors and network issues)
-          await delay(API_RETRY_DELAY_MS);
-        }
-      }
-
-      if (disableRedirectOnUnauthenticated) {
-        setAuthError(lastError);
-        setIsAuthenticated(false);
-        setIsLoading(false);
-      } else {
-        // Preserve the current page for when the user returns after re-authentication.
-        window.location.href = resolvedLoginUrl;
-      }
-    };
-
-    fetchSession();
+    validateSession();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -354,6 +384,7 @@ export function WristbandAuthProvider<TSessionMetaData = unknown>({
         tenantId,
         updateMetadata,
         userId,
+        validateSession,
       }}
     >
       {children}

--- a/src/hooks/use-wristband-auth.ts
+++ b/src/hooks/use-wristband-auth.ts
@@ -5,7 +5,7 @@ import { IWristbandAuthContext } from '../types/auth-provider-types';
 
 export function useWristbandAuth(): Pick<
   IWristbandAuthContext,
-  'isAuthenticated' | 'isLoading' | 'authStatus' | 'authError' | 'clearAuthData'
+  'isAuthenticated' | 'isLoading' | 'authStatus' | 'authError' | 'clearAuthData' | 'validateSession'
 > {
   const context = useContext(WristbandAuthContext);
 
@@ -19,5 +19,6 @@ export function useWristbandAuth(): Pick<
     clearAuthData: context.clearAuthData,
     isAuthenticated: context.isAuthenticated,
     isLoading: context.isLoading,
+    validateSession: context.validateSession,
   };
 }

--- a/src/types/auth-provider-types.ts
+++ b/src/types/auth-provider-types.ts
@@ -134,6 +134,23 @@ export interface IWristbandAuthContext<TSessionMetadata = unknown> {
    * Available only when authentication is successful.
    */
   userId: string;
+  /**
+   * Re-validates the authenticated user's session by re-fetching from the session endpoint
+   * and updating auth state. Useful in scenarios where authentication state may have changed
+   * without a full page reload, such as after completing an auth flow in a popup window or
+   * recovering from an unauthenticated state when `disableRedirectOnUnauthenticated` is `true`.
+   *
+   * @example
+   * ```typescript
+   * const { validateSession } = useWristbandAuth();
+   *
+   * const handleLoginSuccess = async () => {
+   *   await validateSession();
+   *   navigate('/dashboard');
+   * };
+   * ```
+   */
+  validateSession: () => Promise<void>;
 }
 
 export interface IWristbandAuthProviderProps<TSessionMetadata = unknown>

--- a/test/context/wristband-auth-context.test.tsx
+++ b/test/context/wristband-auth-context.test.tsx
@@ -20,6 +20,7 @@ describe('WristbandAuthContext', () => {
       clearAuthData: vi.fn(),
       clearToken: vi.fn(),
       getToken: vi.fn(),
+      validateSession: vi.fn(),
     };
 
     // Test consumer component

--- a/test/context/wristband-auth-provider.test.tsx
+++ b/test/context/wristband-auth-provider.test.tsx
@@ -627,6 +627,252 @@ describe('WristbandAuthProvider', () => {
     });
   });
 
+  describe('validateSession', () => {
+    // Test consumer that exposes validateSession for manual invocation
+    const TestConsumerWithValidateSession = () => {
+      const context = useContext(WristbandAuthContext);
+      return (
+        <div>
+          <div data-testid="auth-error">{context?.authError?.message || 'no-error'}</div>
+          <div data-testid="auth-error-code">{context?.authError?.code || 'no-code'}</div>
+          <div data-testid="auth-status">{context?.authStatus}</div>
+          <div data-testid="is-authenticated">{String(context?.isAuthenticated)}</div>
+          <div data-testid="is-loading">{String(context?.isLoading)}</div>
+          <div data-testid="user-id">{context?.userId || 'no-user-id'}</div>
+          <div data-testid="tenant-id">{context?.tenantId || 'no-tenant-id'}</div>
+          <div data-testid="metadata">{JSON.stringify(context?.metadata)}</div>
+          <button data-testid="validate-session" onClick={() => context?.validateSession?.()}>
+            Validate Session
+          </button>
+        </div>
+      );
+    };
+
+    it('re-validates successfully after being unauthenticated', async () => {
+      const mockSessionData = { userId: 'user-123', tenantId: 'tenant-456', metadata: { name: 'Test User' } };
+
+      const unauthorizedError = new ApiError('Unauthorized');
+      unauthorizedError.status = 401;
+
+      // First call (on mount) fails with 401, second call (manual validateSession) succeeds
+      vi.mocked(apiClient.get)
+        .mockRejectedValueOnce(unauthorizedError)
+        .mockResolvedValueOnce({ data: mockSessionData, status: 200, headers: new Headers() });
+
+      render(
+        <WristbandAuthProvider {...defaultProps} disableRedirectOnUnauthenticated={true}>
+          <TestConsumerWithValidateSession />
+        </WristbandAuthProvider>
+      );
+
+      // Wait for initial unauthenticated state
+      await waitFor(() => {
+        expect(screen.getByTestId('auth-status').textContent).toBe('UNAUTHENTICATED');
+        expect(screen.getByTestId('is-authenticated').textContent).toBe('false');
+        expect(screen.getByTestId('is-loading').textContent).toBe('false');
+        expect(screen.getByTestId('auth-error-code').textContent).toBe('UNAUTHENTICATED');
+      });
+
+      // Manually call validateSession (simulates post-popup-login scenario)
+      await act(async () => screen.getByTestId('validate-session').click());
+
+      // Should now be authenticated
+      await waitFor(() => {
+        expect(screen.getByTestId('auth-status').textContent).toBe('AUTHENTICATED');
+        expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
+        expect(screen.getByTestId('is-loading').textContent).toBe('false');
+        expect(screen.getByTestId('auth-error').textContent).toBe('no-error');
+        expect(screen.getByTestId('auth-error-code').textContent).toBe('no-code');
+        expect(screen.getByTestId('user-id').textContent).toBe('user-123');
+        expect(screen.getByTestId('tenant-id').textContent).toBe('tenant-456');
+        expect(JSON.parse(screen.getByTestId('metadata').textContent || '{}')).toEqual(mockSessionData.metadata);
+      });
+
+      expect(apiClient.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('sets isLoading to true during re-validation', async () => {
+      const mockSessionData = { userId: 'user-123', tenantId: 'tenant-456', metadata: { name: 'Test User' } };
+
+      // First call (on mount) succeeds
+      vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockSessionData, status: 200, headers: new Headers() });
+
+      render(
+        <WristbandAuthProvider {...defaultProps}>
+          <TestConsumerWithValidateSession />
+        </WristbandAuthProvider>
+      );
+
+      // Wait for initial authenticated state
+      await waitFor(() => {
+        expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
+        expect(screen.getByTestId('is-loading').textContent).toBe('false');
+      });
+
+      // Set up a slow second call so we can observe the loading state
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let resolveSession: (value: any) => void;
+      vi.mocked(apiClient.get).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSession = resolve;
+          })
+      );
+
+      // Trigger validateSession
+      act(() => {
+        screen.getByTestId('validate-session').click();
+      });
+
+      // Should immediately be in loading state
+      await waitFor(() => {
+        expect(screen.getByTestId('is-loading').textContent).toBe('true');
+      });
+
+      // Resolve the session call
+      await act(async () => {
+        resolveSession!({ data: mockSessionData, status: 200, headers: new Headers() });
+      });
+
+      // Should be back to authenticated and not loading
+      await waitFor(() => {
+        expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
+        expect(screen.getByTestId('is-loading').textContent).toBe('false');
+      });
+    });
+
+    it('redirects to login when re-validation fails and redirect is enabled', async () => {
+      const mockSessionData = { userId: 'user-123', tenantId: 'tenant-456', metadata: { name: 'Test User' } };
+
+      const unauthorizedError = new ApiError('Unauthorized');
+      unauthorizedError.status = 401;
+
+      const resolvedLoginUrl = '/api/auth/login?return_url=https%3A%2F%2Fcurrent-page.com%2Fpath';
+      vi.mocked(authProviderUtils.resolveAuthProviderLoginUrl).mockReturnValue(resolvedLoginUrl);
+
+      // First call (on mount) succeeds, second call (manual validateSession) fails
+      vi.mocked(apiClient.get)
+        .mockResolvedValueOnce({ data: mockSessionData, status: 200, headers: new Headers() })
+        .mockRejectedValueOnce(unauthorizedError);
+
+      render(
+        <WristbandAuthProvider {...defaultProps}>
+          <TestConsumerWithValidateSession />
+        </WristbandAuthProvider>
+      );
+
+      // Wait for initial authenticated state
+      await waitFor(() => expect(screen.getByTestId('is-authenticated').textContent).toBe('true'));
+
+      // Manually call validateSession
+      await act(async () => screen.getByTestId('validate-session').click());
+
+      // Should redirect to login
+      await waitFor(() => {
+        expect(window.location.href).toBe(resolvedLoginUrl);
+      });
+    });
+
+    it('sets unauthenticated state when re-validation fails and redirect is disabled', async () => {
+      const mockSessionData = { userId: 'user-123', tenantId: 'tenant-456', metadata: { name: 'Test User' } };
+
+      const unauthorizedError = new ApiError('Unauthorized');
+      unauthorizedError.status = 401;
+
+      // First call (on mount) succeeds, second call (manual validateSession) fails
+      vi.mocked(apiClient.get)
+        .mockResolvedValueOnce({ data: mockSessionData, status: 200, headers: new Headers() })
+        .mockRejectedValueOnce(unauthorizedError);
+
+      render(
+        <WristbandAuthProvider {...defaultProps} disableRedirectOnUnauthenticated={true}>
+          <TestConsumerWithValidateSession />
+        </WristbandAuthProvider>
+      );
+
+      // Wait for initial authenticated state
+      await waitFor(() => expect(screen.getByTestId('is-authenticated').textContent).toBe('true'));
+
+      // Manually call validateSession
+      await act(async () => screen.getByTestId('validate-session').click());
+
+      // Should be unauthenticated with error set
+      await waitFor(() => {
+        expect(screen.getByTestId('auth-status').textContent).toBe('UNAUTHENTICATED');
+        expect(screen.getByTestId('is-authenticated').textContent).toBe('false');
+        expect(screen.getByTestId('is-loading').textContent).toBe('false');
+        expect(screen.getByTestId('auth-error-code').textContent).toBe('UNAUTHENTICATED');
+        expect(window.location.href).toBe('https://current-page.com/path');
+      });
+    });
+
+    it('calls onSessionSuccess again on manual re-validation', async () => {
+      const mockSessionData = { userId: 'user-123', tenantId: 'tenant-456', metadata: { name: 'Test User' } };
+      const onSessionSuccessMock = vi.fn();
+
+      vi.mocked(apiClient.get)
+        .mockResolvedValueOnce({ data: mockSessionData, status: 200, headers: new Headers() })
+        .mockResolvedValueOnce({ data: mockSessionData, status: 200, headers: new Headers() });
+
+      render(
+        <WristbandAuthProvider {...defaultProps} onSessionSuccess={onSessionSuccessMock}>
+          <TestConsumerWithValidateSession />
+        </WristbandAuthProvider>
+      );
+
+      // Wait for initial authenticated state
+      await waitFor(() => expect(screen.getByTestId('is-authenticated').textContent).toBe('true'));
+      expect(onSessionSuccessMock).toHaveBeenCalledTimes(1);
+
+      // Manually call validateSession
+      await act(async () => screen.getByTestId('validate-session').click());
+
+      // onSessionSuccess should have been called again
+      await waitFor(() => expect(onSessionSuccessMock).toHaveBeenCalledTimes(2));
+      expect(onSessionSuccessMock).toHaveBeenCalledWith(mockSessionData);
+    });
+
+    it('applies transformSessionMetadata on manual re-validation', async () => {
+      const mockSessionData = {
+        userId: 'user-123',
+        tenantId: 'tenant-456',
+        metadata: { displayName: 'Test User', userRole: 'admin' },
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const transformFn = vi.fn((rawMetadata: any) => ({
+        name: rawMetadata.displayName,
+        role: rawMetadata.userRole,
+      }));
+
+      vi.mocked(apiClient.get)
+        .mockResolvedValueOnce({ data: mockSessionData, status: 200, headers: new Headers() })
+        .mockResolvedValueOnce({ data: mockSessionData, status: 200, headers: new Headers() });
+
+      render(
+        <WristbandAuthProvider {...defaultProps} transformSessionMetadata={transformFn}>
+          <TestConsumerWithValidateSession />
+        </WristbandAuthProvider>
+      );
+
+      // Wait for initial authenticated state
+      await waitFor(() => expect(screen.getByTestId('is-authenticated').textContent).toBe('true'));
+      expect(transformFn).toHaveBeenCalledTimes(1);
+
+      // Manually call validateSession
+      await act(async () => screen.getByTestId('validate-session').click());
+
+      // Transform should have been called again and metadata updated
+      await waitFor(() => {
+        expect(transformFn).toHaveBeenCalledTimes(2);
+        expect(JSON.parse(screen.getByTestId('metadata').textContent || '{}')).toEqual({
+          name: 'Test User',
+          role: 'admin',
+        });
+      });
+    });
+  });
+
   describe('authError state management', () => {
     it('exposes authError in context when disableRedirectOnUnauthenticated is true', async () => {
       const error = new ApiError('Unauthorized');
@@ -1687,7 +1933,7 @@ describe('WristbandAuthProvider', () => {
     });
   });
 
-  describe('fetchSession retry logic', () => {
+  describe('validateSession retry logic', () => {
     it('retries on 5xx server errors and succeeds on second attempt', async () => {
       // Mock console.log to prevent error output in tests
       console.log = vi.fn();

--- a/test/hooks/use-wristband-auth.test.tsx
+++ b/test/hooks/use-wristband-auth.test.tsx
@@ -13,8 +13,9 @@ describe('useWristbandAuth', () => {
     vi.resetAllMocks();
   });
 
-  it('should return authentication state and clearAuthData from context', () => {
+  it('should return authentication state, clearAuthData, and validateSession from context', () => {
     const mockClearAuthData = vi.fn();
+    const mockValidateSession = vi.fn();
 
     const contextValue: IWristbandAuthContext = {
       isAuthenticated: true,
@@ -28,6 +29,7 @@ describe('useWristbandAuth', () => {
       clearAuthData: mockClearAuthData,
       clearToken: vi.fn(),
       getToken: vi.fn(),
+      validateSession: mockValidateSession,
     };
 
     // Create a wrapper that provides the mock context
@@ -45,11 +47,12 @@ describe('useWristbandAuth', () => {
       isLoading: false,
       authStatus: 'AUTHENTICATED',
       clearAuthData: mockClearAuthData,
+      validateSession: mockValidateSession,
     });
 
     // Verify that the returned object only has the expected keys
     expect(Object.keys(result.current).sort()).toEqual(
-      ['authError', 'authStatus', 'clearAuthData', 'isAuthenticated', 'isLoading'].sort()
+      ['authError', 'authStatus', 'clearAuthData', 'isAuthenticated', 'isLoading', 'validateSession'].sort()
     );
   });
 
@@ -68,6 +71,7 @@ describe('useWristbandAuth', () => {
       clearAuthData: mockClearAuthData,
       clearToken: vi.fn(),
       getToken: vi.fn(),
+      validateSession: vi.fn(),
     };
 
     const wrapper = ({ children }: { children: ReactNode }) => (
@@ -83,6 +87,39 @@ describe('useWristbandAuth', () => {
 
     // Verify the mock was called
     expect(mockClearAuthData).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call validateSession when invoked', async () => {
+    const mockValidateSession = vi.fn().mockResolvedValue(undefined);
+
+    const contextValue: IWristbandAuthContext = {
+      isAuthenticated: false,
+      isLoading: false,
+      authStatus: 'UNAUTHENTICATED',
+      authError: null,
+      userId: '',
+      tenantId: '',
+      metadata: {},
+      updateMetadata: vi.fn(),
+      clearAuthData: vi.fn(),
+      clearToken: vi.fn(),
+      getToken: vi.fn(),
+      validateSession: mockValidateSession,
+    };
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <WristbandAuthContext.Provider value={contextValue}>{children}</WristbandAuthContext.Provider>
+    );
+
+    const { result } = renderHook(() => useWristbandAuth(), { wrapper });
+
+    // Call validateSession
+    await act(async () => {
+      await result.current.validateSession();
+    });
+
+    // Verify the mock was called
+    expect(mockValidateSession).toHaveBeenCalledTimes(1);
   });
 
   it('should throw error when used outside of WristbandAuthProvider', () => {
@@ -128,6 +165,7 @@ describe('useWristbandAuth', () => {
       clearAuthData: mockClearAuthData,
       clearToken: vi.fn(),
       getToken: vi.fn(),
+      validateSession: vi.fn(),
     };
 
     // Render the test component with the context provider
@@ -165,6 +203,7 @@ describe('useWristbandAuth', () => {
           clearAuthData: vi.fn(),
           clearToken: vi.fn(),
           getToken: vi.fn(),
+          validateSession: vi.fn(),
         } as IWristbandAuthContext,
         expected: {
           authError: null,
@@ -172,6 +211,7 @@ describe('useWristbandAuth', () => {
           isLoading: true,
           authStatus: 'LOADING',
           clearAuthData: expect.any(Function),
+          validateSession: expect.any(Function),
         },
       },
       {
@@ -187,6 +227,7 @@ describe('useWristbandAuth', () => {
           clearAuthData: vi.fn(),
           clearToken: vi.fn(),
           getToken: vi.fn(),
+          validateSession: vi.fn(),
         } as IWristbandAuthContext,
         expected: {
           authError: null,
@@ -194,6 +235,7 @@ describe('useWristbandAuth', () => {
           isLoading: false,
           authStatus: 'AUTHENTICATED',
           clearAuthData: expect.any(Function),
+          validateSession: expect.any(Function),
         },
       },
       {
@@ -209,6 +251,7 @@ describe('useWristbandAuth', () => {
           clearAuthData: vi.fn(),
           clearToken: vi.fn(),
           getToken: vi.fn(),
+          validateSession: vi.fn(),
         } as IWristbandAuthContext,
         expected: {
           authError: null,
@@ -216,6 +259,7 @@ describe('useWristbandAuth', () => {
           isLoading: false,
           authStatus: 'UNAUTHENTICATED',
           clearAuthData: expect.any(Function),
+          validateSession: expect.any(Function),
         },
       },
     ];
@@ -247,6 +291,7 @@ describe('useWristbandAuth', () => {
       clearAuthData: vi.fn(),
       clearToken: vi.fn(),
       getToken: vi.fn(),
+      validateSession: vi.fn(),
     };
 
     const wrapper = ({ children }: { children: ReactNode }) => (
@@ -273,6 +318,7 @@ describe('useWristbandAuth', () => {
       clearAuthData: vi.fn(),
       clearToken: vi.fn(),
       getToken: vi.fn(),
+      validateSession: vi.fn(),
     };
 
     const wrapper = ({ children }: { children: ReactNode }) => (
@@ -310,6 +356,7 @@ describe('useWristbandAuth', () => {
         clearAuthData: vi.fn(),
         clearToken: vi.fn(),
         getToken: vi.fn(),
+        validateSession: vi.fn(),
       };
 
       const wrapper = ({ children }: { children: ReactNode }) => (


### PR DESCRIPTION
# Release 3.2.0

## New Features

### ✨ `validateSession()` Added to `useWristbandAuth()`

The `validateSession()` function has been added to the `useWristbandAuth()` hook, allowing applications to manually re-fetch the authenticated user's session and update auth state without a full page reload.

**Behavior:**
- Sets `isLoading` to `true` during the request
- On success: Updates `userId`, `tenantId`, `metadata`, and sets `isAuthenticated` to `true`
- On failure with `disableRedirectOnUnauthenticated: true`: Sets `authError` and `isAuthenticated` to `false`
- On failure with `disableRedirectOnUnauthenticated: false`: Redirects to the login URL

**Primary use cases:**
- Popup-based OAuth login flows where the parent window needs to revalidate auth state after the popup closes
- Public pages with `disableRedirectOnUnauthenticated={true}` that need to check if the user has since authenticated